### PR TITLE
Sync API Modifications, New Subcommands, API Changes and Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,13 @@ zk is_unrecoverable
 
 Return true if the zookeeper C library says the connection state can't be recovered.
 
-If this returns true then the application must close the zhandle object and try to reconnect.
+If this returns true then the application must destroy the zookeeper object and reconnect.
+
+```tcl
+zk destroy
+```
+
+Destroys the Zookeeper object, disconnecting from Zookeeper and removing all watch or async callbacks in the process.
 
 Watch Callbacks
 ---

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ zk destroy
 
 Destroys the Zookeeper object, disconnecting from Zookeeper and removing all watch or async callbacks in the process.
 
+Prior to v1.1.0 you must use `rename zk ""` instead.
+
 ```tcl
 zk close
 ```

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ zk destroy
 
 Destroys the Zookeeper object, disconnecting from Zookeeper and removing all watch or async callbacks in the process.
 
+```tcl
+zk close
+```
+
+Alias for the `destroy` sub-command.
+
 Watch Callbacks
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Open source under the permissive Berkeley copyright; see file [LICENSE](LICENSE)
 
 Requirements
 ---
-Requires the Apache Zookeeper C/C++ library [libzookeeper](https://zookeeper.apache.org/doc/trunk/zookeeperProgrammers.html) be installed.
+Requires the Apache Zookeeper C/C++ library [libzookeeper](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html) be installed.
 
 Building
 ---
@@ -59,9 +59,10 @@ package require zookeeper
 
 zookeeper::zookeeper debug_level debug
 ```
-debug level can be debug, info, warn or error.
 
-`zookeeper::zookeeper version`` returns the version of the C client, like **3.4.6**.  (The version of zookeeper Tcl can always be determined using `package require zookeeper` or one of various other Tcl package methods.)
+debug level can be debug, info, warn, error or none.
+
+`zookeeper::zookeeper version` returns the version of the C client, like **3.4.6**.  (The version of zookeeper Tcl can always be determined using `package require zookeeper` or one of various other Tcl package methods.)
 
 zookeeper::zookeeper init name host timeout ?-async callback?
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Return 1 if the path exists and 0 if it doesn't.  **-watch**, **-stat** and **-v
 
 If **-async** is specified, the request is made asynchronously and *callback* is invoked with a Tcl list of key-value pairs as an argument when the answer arrives.
 
-Neither -watch, -stat or -version can be specified when -async is used.
+Neither -stat nor -version can be specified when -async is used.
 
 ```tcl
 zk children $path ?-async callback? ?-watch code?

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Functionality
 
 - Provides a natural Tcl interface
 - Fast
-- Synchronous interface for simplicity and convenience
+- Synchronous interface for simplicity and convenience (See note)
 - Asynchronous interface for performance
 - Thread safe
 - Free!
+
+Note: prior to v1.1.0 the synchronous interface maintained the Tcl event loop. This has led to problems and hard to find bugs, and
+now the Tcl event loop is blocked while communicating with the server using the non-async API. This should have minimal impact, but some
+programs may need to change to the asynchronous API.
 
 License
 ---
@@ -49,6 +53,10 @@ package require zookeeper
 
 Versions
 ---
+
+v1.0.0 -- initial release.
+
+v1.1.0 -- change to synchronous Zookeeper API for synchronous calls.
 
 
 Overview

--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([zookeeper], [1.0.2])
+AC_INIT([zookeeper], [1.1.0])
 
 #--------------------------------------------------------------------
 #Extract the major.minor part from the 3-part version number

--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([zookeeper], [1.0.1])
+AC_INIT([zookeeper], [1.0.2])
 
 #--------------------------------------------------------------------
 #Extract the major.minor part from the 3-part version number

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1728,11 +1728,6 @@ zootcl_set_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 
     assert (zo->zookeeper_object_magic == ZOOKEEPER_OBJECT_MAGIC);
 
-	if (zoo_state(zh) == 0) {
-		Tcl_SetObjResult(interp, Tcl_NewStringObj("Cannt use a closed handle", -1));
-		return TCL_ERROR;
-	}
-
 	if ((objc < 5) || (objc > 7)) {
 		Tcl_WrongNumArgs (interp, 2, objv, "path data version ?-async callback?");
 		return TCL_ERROR;
@@ -2048,8 +2043,8 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
     assert (zo->zookeeper_object_magic == ZOOKEEPER_OBJECT_MAGIC);
 
 	ZOOAPI zhandle_t *zh = zo->zh;
-	int optIndex;
 
+	int optIndex;
     static CONST char *options[] = {
         "get",
         "children",
@@ -2093,6 +2088,13 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
         return TCL_ERROR;
     }
 
+	// do not allow most subcommands on closed handles
+	if ((enum options) optIndex != OPT_STATE && zoo_state(zh) == 0) {
+		Tcl_SetObjResult(interp, Tcl_NewStringObj("Cannot use a closed handle", -1));
+		return TCL_ERROR;
+	}
+
+	// hand off each subcommand to its proper handler
     switch ((enum options) optIndex) {
 		case OPT_EXISTS:
 			return zootcl_exists_subcommand(interp, objc, objv, zh, zo);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1744,16 +1744,10 @@ zootcl_set_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 
 	if (callbackObj == NULL) {
 		// synchronous set
-		zootcl_syncCallbackContext *zsc = (zootcl_syncCallbackContext *)ckalloc (sizeof (zootcl_syncCallbackContext));
-		zsc->zo = zo;
-		zsc->syncDone = 0;
-		status = zoo_aset (zh, path, buffer, bufferLen, version, zootcl_sync_stat_completion_callback, zsc);
-		if (zootcl_wait (zo, zsc) == TCL_ERROR) {
-			return TCL_ERROR;
-		}
-		int rc = zsc->rc;
-		ckfree (zsc);
-		return zootcl_set_tcl_return_code (interp, rc);
+		struct Stat *stat = (struct Stat *)ckalloc (sizeof (struct Stat));
+		status = zoo_set2(zh, path, buffer, bufferLen, version, stat);
+
+		ckfree (stat);
 	} else {
 		// asynchronous set
 		zootcl_callbackContext *ztc = (zootcl_callbackContext *)ckalloc (sizeof (zootcl_callbackContext));

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1728,6 +1728,11 @@ zootcl_set_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 
     assert (zo->zookeeper_object_magic == ZOOKEEPER_OBJECT_MAGIC);
 
+	if (zoo_state(zh) == 0) {
+		Tcl_SetObjResult(interp, Tcl_NewStringObj("Cannt use a closed handle", -1));
+		return TCL_ERROR;
+	}
+
 	if ((objc < 5) || (objc > 7)) {
 		Tcl_WrongNumArgs (interp, 2, objv, "path data version ?-async callback?");
 		return TCL_ERROR;

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2142,9 +2142,9 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 			socklen_t sockaddr_len; 
 			zookeeper_get_connected_host(zh, &sa, &sockaddr_len);
 
-			char host[256];
-			host[255] = '\0';
-			get_ip_str(&sa, host, 255);
+			char host[INET6_ADDRSTRLEN];
+			host[INET6_ADDRSTRLEN - 1] = '\0';
+			get_ip_str(&sa, host, INET6_ADDRSTRLEN - 1);
 
 			Tcl_SetObjResult(interp, Tcl_NewStringObj(host, -1));
 			break;

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -15,6 +15,7 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netdb.h>
 
 int
 zootcl_EventProc (Tcl_Event *tevPtr, int flags);
@@ -254,7 +255,8 @@ int zootcl_stat_to_array (Tcl_Interp *interp, char *arrayName, struct Stat *stat
  * http://beej.us/guide/bgnet/examples/client.c
  *
  * Results:
- *      returns AF family constant for use with inet_ntop
+ *      returns pointer to correct sockaddr_in depending on 
+ *      whether sa is IPv4 or IPv6
  *
  * Side effects:
  *		none
@@ -2122,15 +2124,15 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		{
 			struct sockaddr sa;
 			socklen_t sa_len = sizeof sa; 
-			char host[INET6_ADDRSTRLEN + 1];
-			strcpy(host, "");
+			char host[1024];
+			char service[20];
 
 			if (zookeeper_get_connected_host(zh, &sa, &sa_len)) {
-				inet_ntop(sa.sa_family, get_in_addr(&sa), host, INET6_ADDRSTRLEN);
+				getnameinfo(&sa, sa_len, host, sizeof host, service, sizeof service, 0);
+			} else {
+				strcpy(host, "");
 			}
 
-			// make sure host is NULL terminated
-			host[INET6_ADDRSTRLEN] = '\0';
 			Tcl_SetObjResult(interp, Tcl_NewStringObj(host, -1));
 			break;
 		}

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1598,15 +1598,19 @@ zootcl_children_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], 
 		}
 		
 		int count = strings ? strings->count : 0;
-		Tcl_Obj **listObjv = (Tcl_Obj **)ckalloc (sizeof(Tcl_Obj *) * count);
+        if (count > 0) {
+            Tcl_Obj **listObjv = (Tcl_Obj **)ckalloc (sizeof(Tcl_Obj *) * count);
 
-		for (i = 0; i < count; i++) {
-			listObjv[i] = Tcl_NewStringObj (strings->data[i], -1);
-		}
+            for (i = 0; i < count; i++) {
+                listObjv[i] = Tcl_NewStringObj (strings->data[i], -1);
+            }
 
-		Tcl_Obj *listObj = Tcl_NewListObj (count, listObjv);
-		
-		Tcl_SetObjResult (interp, listObj);
+            Tcl_Obj *listObj = Tcl_NewListObj (count, listObjv);
+		    Tcl_SetObjResult (interp, listObj);
+        } else {
+            Tcl_SetObjResult (interp, Tcl_NewListObj (count, NULL));    
+        }
+
 		ckfree (strings);
 	} else {
 		zootcl_callbackContext *ztc = (zootcl_callbackContext *)ckalloc (sizeof (zootcl_callbackContext));

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1921,6 +1921,14 @@ zootcl_delete_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZO
 int
 zootcl_destroy_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAPI zhandle_t *zh, zootcl_objectClientData *zo)
 {
+    // Remove the command exit handler and delete the command
+	Tcl_CmdInfo *infoPtr = (Tcl_CmdInfo *) ckalloc (sizeof (Tcl_CmdInfo));
+	infoPtr->deleteProc = NULL;
+	Tcl_SetCommandInfoFromToken(zo->cmdToken, infoPtr);
+	ckfree(infoPtr);
+	Tcl_DeleteCommandFromToken(interp, zo->cmdToken);
+
+    // Call the object deletion function and return
     zootcl_zookeeperObjectDelete ((ClientData)zo);
     return TCL_OK;
 }

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2054,6 +2054,7 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		"server",
         "recv_timeout",
         "is_unrecoverable",
+		"close",
 		"destroy",
         NULL
     };
@@ -2069,6 +2070,7 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		OPT_SERVER,
 		OPT_RECV_TIMEOUT,
 		OPT_IS_UNRECOVERABLE,
+		OPT_CLOSE,
 		OPT_DESTROY
     };
 
@@ -2149,6 +2151,9 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 			Tcl_SetObjResult (interp, Tcl_NewBooleanObj (is_unrecoverable (zh) == ZINVALIDSTATE));
 			break;
 		}
+
+		case OPT_CLOSE:
+			return zootcl_set_tcl_return_code(interp, zookeeper_close(zh));
 
 		case OPT_DESTROY:
 			return zootcl_destroy_subcommand(interp, objc, objv, zh, zo);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -3,7 +3,7 @@
 /*
  * zootcl - Tcl interface to Apache Zookeeper
  *
- * Copyright (C) 2016 - 2018 FlightAware LLC
+ * Copyright (C) 2016 - 2019 FlightAware LLC
  *
  * freely redistributable under the Berkeley license
  */

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1644,7 +1644,7 @@ zootcl_children_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], 
 		if (status != ZOK && status != ZNONODE) {
 			ckfree (strings);
 			return zootcl_set_tcl_return_code (interp, status);
-		} else {
+		} else if (status == ZNONODE) {
 			// do not consider a non-existent path to be an error in this case
 			status = ZOK;
 			strings->count = 0;

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1084,9 +1084,10 @@ zootcl_EventProc (Tcl_Event *tevPtr, int flags) {
 /*
  *--------------------------------------------------------------
  *
- * zootcl_DeleteEventsForDeletedObject - delete any events where the
- *  underlying zookeepertcl object has been deleted
- *  this can happen, e.g., if an -async option is used and then
+ * zootcl_DeleteEventsForDeletedObject - let Tcl_DeleteEvents know
+ *  it needs to delete any events where the underlying
+ *  zookeepertcl object has been deleted.
+ *  This can happen, e.g., if an -async option is used and then
  *  the zookeepertcl object is destroyed before the event has a
  *  chance to fire
  *

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1530,7 +1530,7 @@ zootcl_get_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 			Tcl_SetObjResult (interp, Tcl_NewBooleanObj (1));
 		}
 
-		if (zootcl_stat_to_array (interp, statArray, stat) == TCL_ERROR) {
+		if (statArray && zootcl_stat_to_array (interp, statArray, stat) == TCL_ERROR) {
 			ckfree (stat);
 			return TCL_ERROR;
 		}

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1487,7 +1487,9 @@ zootcl_get_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 
 	// if asyncCallbackObj is null, do the synchronous version
 	if (asyncCallbackObj == NULL) {
-		int bufferLen = 1048576;
+		// make the buffer 1MB + 1 byte since 1MB is the
+		// default maximum size for a znode's data
+		int bufferLen = 1048576 + 1;
 		char buffer[bufferLen];
 		struct Stat *stat = (struct Stat *)ckalloc (sizeof (struct Stat));
 

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1100,7 +1100,7 @@ zootcl_EventProc (Tcl_Event *tevPtr, int flags) {
  */
 int zootcl_DeleteEventsForDeletedObject (Tcl_Event *tevPtr, ClientData clientData) {
 	zootcl_objectClientData *zo = (zootcl_objectClientData *)clientData;    
-	return !zo || zo->zookeeper_object_magic == -1;
+	return zo && zo->zookeeper_object_magic != ZOOKEEPER_OBJECT_MAGIC;
 }
 
 /*
@@ -1138,9 +1138,9 @@ zootcl_zookeeperObjectDelete (ClientData clientData)
     	zo->zookeeper_object_magic = -1;
 
 	zookeeper_close (zo->zh);
-    	ckfree((char *)clientData);
+	Tcl_DeleteEvents (zootcl_DeleteEventsForDeletedObject, clientData);
 
-	Tcl_DeleteEvents(zootcl_DeleteEventsForDeletedObject, clientData);
+    	ckfree((char *)clientData);
 }
 
 /*

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2124,11 +2124,13 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		{
 			struct sockaddr sa;
 			socklen_t sa_len = sizeof sa; 
+			int res;
 			char host[1024];
 
 			if (zookeeper_get_connected_host(zh, &sa, &sa_len)) {
-				if (getnameinfo(&sa, sa_len, host, sizeof host, NULL, 0, 0) != 0) {
-					strcpy(host, "");	
+				res = getnameinfo(&sa, sa_len, host, sizeof host, NULL, 0, 0);
+				if (res != 0) {
+					strcpy(host, gai_strerror(res));
 				}
 			} else {
 				strcpy(host, "");

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2125,10 +2125,11 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 			struct sockaddr sa;
 			socklen_t sa_len = sizeof sa; 
 			char host[1024];
-			char service[20];
 
 			if (zookeeper_get_connected_host(zh, &sa, &sa_len)) {
-				getnameinfo(&sa, sa_len, host, sizeof host, service, sizeof service, 0);
+				if (getnameinfo(&sa, sa_len, host, sizeof host, NULL, 0, 0) != 0) {
+					strcpy(host, "");	
+				}
 			} else {
 				strcpy(host, "");
 			}

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -412,7 +412,7 @@ zootcl_strings_completion_callback (int rc, const struct String_vector *strings,
 
 	// marshall the zookeeper strings into Tcl string objects
 	// and make a Tcl list object of them
-        int count = strings ? strings->count : 0;
+    int count = strings ? strings->count : 0;
 	Tcl_Obj **listObjv = (Tcl_Obj **)ckalloc (sizeof(Tcl_Obj *) * count);
 
 	int i;
@@ -1624,18 +1624,17 @@ zootcl_children_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], 
 			strings->count = 0;
 		}
 		
-		int count = strings ? strings->count : 0;
-        if (count > 0) {
-            Tcl_Obj **listObjv = (Tcl_Obj **)ckalloc (sizeof(Tcl_Obj *) * count);
+        if (strings->count > 0) {
+            Tcl_Obj **listObjv = (Tcl_Obj **)ckalloc (sizeof(Tcl_Obj *) * strings->count);
 
-            for (i = 0; i < count; i++) {
+            for (i = 0; i < strings->count; i++) {
                 listObjv[i] = Tcl_NewStringObj (strings->data[i], -1);
             }
 
-            Tcl_Obj *listObj = Tcl_NewListObj (count, listObjv);
+            Tcl_Obj *listObj = Tcl_NewListObj (strings->count, listObjv);
 		    Tcl_SetObjResult (interp, listObj);
         } else {
-            Tcl_SetObjResult (interp, Tcl_NewListObj (count, NULL));    
+            Tcl_SetObjResult (interp, Tcl_NewListObj (0, NULL));    
         }
 
 		ckfree (strings);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2261,7 +2261,6 @@ zootcl_init_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	zo->threadId = Tcl_GetCurrentThread ();
 	zo->channel = NULL;
 	zo->currentFD = -1;
-	zo->closed = 0;
 	zo->initCallbackObj = callbackObj;
 
 	zhandle_t *zh = zookeeper_init (hosts, zootcl_init_callback, timeout, NULL, zo, 0);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1889,9 +1889,6 @@ zootcl_delete_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZO
 	if (callbackObj == NULL) {
 		// synchronous delete
 		status = zoo_delete(zh, path, version);
-		if (status != ZOK) {
-			return zootcl_set_tcl_return_code (interp, status);
-		}
 	} else {
 		zootcl_callbackContext *ztc = (zootcl_callbackContext *)ckalloc (sizeof (zootcl_callbackContext));
 		ztc->callbackObj = callbackObj;

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2089,7 +2089,9 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
     }
 
 	// do not allow most subcommands on closed handles
-	if ((enum options) optIndex != OPT_STATE && zoo_state(zh) == 0) {
+	if (zoo_state(zh) == 0 &&
+		!((enum options) optIndex == OPT_STATE ||
+          (enum options) optIndex == OPT_DESTROY)) {
 		Tcl_SetObjResult(interp, Tcl_NewStringObj("Cannot use a closed handle", -1));
 		return TCL_ERROR;
 	}
@@ -2167,7 +2169,6 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		case OPT_CLOSE:
 		{
 			zo->zh = NULL;
-			zo->currentFD = -1;
 			return zootcl_set_tcl_return_code(interp, zookeeper_close(zh));
 		}
 

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1487,8 +1487,8 @@ zootcl_get_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 
 	// if asyncCallbackObj is null, do the synchronous version
 	if (asyncCallbackObj == NULL) {
-		char buffer[512];
-		int bufferLen = 512;
+		int bufferLen = 1048576;
+		char buffer[bufferLen];
 		struct Stat *stat = (struct Stat *)ckalloc (sizeof (struct Stat));
 
 		status = zoo_wget(zh, path, wfn, (void *)watcherCallbackObj, buffer, &bufferLen, stat);	

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -3,7 +3,7 @@
 /*
  * zootcl - Tcl interface to Apache Zookeeper
  *
- * Copyright (C) 2016 - 2017 FlightAware LLC
+ * Copyright (C) 2016 - 2018 FlightAware LLC
  *
  * freely redistributable under the Berkeley license
  */
@@ -2271,6 +2271,7 @@ zootcl_zookeeperObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_
 				"warn",
 				"info",
 				"debug",
+				"none",
 				NULL
 			};
 
@@ -2278,7 +2279,8 @@ zootcl_zookeeperObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_
 				SUBOPT_ERROR,
 				SUBOPT_WARN,
 				SUBOPT_INFO,
-				SUBOPT_DEBUG
+				SUBOPT_DEBUG,
+				SUBOPT_NONE
 			};
 
 
@@ -2305,6 +2307,10 @@ zootcl_zookeeperObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_
 
 				case SUBOPT_DEBUG:
 					zooLogLevel = ZOO_LOG_LEVEL_DEBUG;
+					break;
+
+				case SUBOPT_NONE:
+					zooLogLevel = (ZooLogLevel) 0;
 					break;
 			}
 

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2121,10 +2121,10 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		case OPT_SERVER:
 		{
 			struct sockaddr sa;
-			socklen_t sockaddr_len; 
+			socklen_t sa_len = sizeof sa; 
 			char host[INET6_ADDRSTRLEN];
 
-			if (zookeeper_get_connected_host(zh, &sa, &sockaddr_len) == NULL) {
+			if (zookeeper_get_connected_host(zh, &sa, &sa_len) == NULL) {
 				strcpy(host, "NULL");
 			} else {
 				inet_ntop(sa.sa_family, get_in_addr(&sa), host, sizeof host);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1850,24 +1850,18 @@ zootcl_create_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZO
 	int status;
 
 	if (callbackObj == NULL) {
-		zootcl_syncCallbackContext *zsc = (zootcl_syncCallbackContext *)ckalloc (sizeof (zootcl_syncCallbackContext));
-		zsc->zo = zo;
-		zsc->syncDone = 0;
+		// sync version
+		int pathBufferLen = 1024;
+		char pathBuffer[pathBufferLen];
+		status = zoo_create(zh, path, value, valueLen, &ZOO_OPEN_ACL_UNSAFE, flags, pathBuffer, pathBufferLen);
 
-		status = zoo_acreate (zh, path, value, valueLen, &ZOO_OPEN_ACL_UNSAFE, flags, zootcl_sync_string_completion_callback, zsc);
 		if (status != ZOK) {
-			ckfree (zsc);
 			return zootcl_set_tcl_return_code (interp, status);
 		}
-		if (zootcl_wait (zo, zsc) == TCL_ERROR) {
-			ckfree (zsc);
-			return TCL_ERROR;
-		}
-		status = zsc->rc;
+
 		if (status == ZOK) {
-			Tcl_SetObjResult (interp, zsc->dataObj);
+			Tcl_SetObjResult (interp, Tcl_NewStringObj(pathBuffer, pathBufferLen));
 		}
-		ckfree (zsc);
 	} else {
 		zootcl_callbackContext *ztc = (zootcl_callbackContext *)ckalloc (sizeof (zootcl_callbackContext));
 		ztc->callbackObj = callbackObj;

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1647,6 +1647,7 @@ zootcl_children_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], 
 		} else {
 			// do not consider a non-existent path to be an error in this case
 			status = ZOK;
+			strings->count = 0;
 		}
 		
 		int count = strings ? strings->count : 0;

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2122,15 +2122,15 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		{
 			struct sockaddr sa;
 			socklen_t sa_len = sizeof sa; 
-			char host[INET6_ADDRSTRLEN];
+			char host[INET6_ADDRSTRLEN + 1];
+			strcpy(host, "");
 
-			if (zookeeper_get_connected_host(zh, &sa, &sa_len) == NULL) {
-				strcpy(host, "NULL");
-			} else {
-				inet_ntop(sa.sa_family, get_in_addr(&sa), host, sizeof host);
+			if (zookeeper_get_connected_host(zh, &sa, &sa_len)) {
+				inet_ntop(sa.sa_family, get_in_addr(&sa), host, INET6_ADDRSTRLEN);
 			}
 
-			host[INET6_ADDRSTRLEN - 1] = '\0';
+			// make sure host is NULL terminated
+			host[INET6_ADDRSTRLEN] = '\0';
 			Tcl_SetObjResult(interp, Tcl_NewStringObj(host, -1));
 			break;
 		}

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1972,6 +1972,28 @@ zootcl_delete_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZO
 /*
  *----------------------------------------------------------------------
  *
+ * zootcl_destroy_subcommand --
+ *
+ *      implement the "destroy" method of a zookeeper tcl command
+ *      object
+ *
+ * Results:
+ *      Always returns TCL_OK whether or not Tcl_DeleteCommandFromToken
+ *		succeeds
+ *
+ *
+ *----------------------------------------------------------------------
+ */
+int
+zootcl_destroy_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAPI zhandle_t *zh, zootcl_objectClientData *zo)
+{
+	Tcl_DeleteCommandFromToken(interp, zo->cmdToken);
+	return TCL_OK;
+}
+
+/*
+ *----------------------------------------------------------------------
+ *
  * zootcl_zookeeperObjectObjCmd --
  *
  *      perform methods of a zookeeper object
@@ -2002,6 +2024,7 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
         "state",
         "recv_timeout",
         "is_unrecoverable",
+		"destroy",
         NULL
     };
 
@@ -2014,7 +2037,8 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		OPT_DELETE,
         OPT_STATE,
 		OPT_RECV_TIMEOUT,
-		OPT_IS_UNRECOVERABLE
+		OPT_IS_UNRECOVERABLE,
+		OPT_DESTROY
     };
 
     // basic command line processing
@@ -2077,6 +2101,9 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 			Tcl_SetObjResult (interp, Tcl_NewBooleanObj (is_unrecoverable (zh) == ZINVALIDSTATE));
 			break;
 		}
+
+		case OPT_DESTROY:
+			return zootcl_destroy_subcommand(interp, objc, objv, zh, zo);
 
 	}
 

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2158,7 +2158,11 @@ zootcl_zookeeperObjectObjCmd(ClientData clientData, Tcl_Interp *interp, int objc
 		}
 
 		case OPT_CLOSE:
+		{
+			zo->zh = NULL;
+			zo->currentFD = -1;
 			return zootcl_set_tcl_return_code(interp, zookeeper_close(zh));
+		}
 
 		case OPT_DESTROY:
 			return zootcl_destroy_subcommand(interp, objc, objv, zh, zo);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1921,29 +1921,8 @@ zootcl_delete_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZO
 int
 zootcl_destroy_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAPI zhandle_t *zh, zootcl_objectClientData *zo)
 {
-	// Close Zookeeper
-	zookeeper_close(zo->zh);
-	zo->zh = NULL;
-
-	// Remove the command exit handler and delete the command
-	Tcl_CmdInfo *infoPtr = (Tcl_CmdInfo *) ckalloc (sizeof (Tcl_CmdInfo));
-	infoPtr->deleteProc = NULL;
-	Tcl_SetCommandInfoFromToken(zo->cmdToken, infoPtr);
-	ckfree(infoPtr);
-	Tcl_DeleteCommandFromToken(interp, zo->cmdToken);
-
-	// Get rid of all event handlers and event sources
-	Tcl_DeleteExitHandler(zootcl_zookeeperObjectDelete, (ClientData)zo);
-	Tcl_DeleteThreadExitHandler(zootcl_zookeeperObjectDelete, (ClientData)zo);
-	if (zo->channel != NULL) {
-		Tcl_DeleteChannelHandler(zo->channel, zootcl_socket_ready, (ClientData)zo);
-		Tcl_DetachChannel(zo->interp, zo->channel);
-	}
-	Tcl_DeleteEventSource(zootcl_EventSetupProc, zootcl_EventCheckProc, (ClientData)zo);
-
-	// Free memory and get outta here
-	ckfree(zo);
-	return TCL_OK;
+    zootcl_zookeeperObjectDelete ((ClientData)zo);
+    return TCL_OK;
 }
 
 /*

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1522,12 +1522,12 @@ zootcl_get_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 			return TCL_ERROR;
 		}
 		status = zsc->rc;
-		if (((status == ZNONODE) || (zsc->dataObj == NULL)) && (dataVarObj != NULL)) {
-			// node doesn't exist or contains no data
-			// and they specified -data, unset their
-			// specified data var and version var and
-			// return 0 indicating no node
-			Tcl_UnsetVar (interp, Tcl_GetString (dataVarObj), 0);
+		
+		// if the node does not exist and -data was specified
+		// unset the var: do the same if a -version var was
+		// also specified and, finally, return 0
+		if (status == ZNONODE && dataVarObj != NULL) {
+			Tcl_UnsetVar(interp, Tcl_GetString(dataVarObj), 0);
 			if (versionVarObj != NULL) {
 				Tcl_UnsetVar (interp, Tcl_GetString (versionVarObj), 0);
 			}
@@ -1545,6 +1545,13 @@ zootcl_get_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 			if (zsc->dataObj != NULL) {
 				Tcl_SetObjResult (interp, zsc->dataObj);
 			}
+		} else if (zsc->dataObj == NULL) { 
+			// if the node does exist, but the data in the znode is NULL
+			// unset the var name specified by -data
+			Tcl_UnsetVar(interp, Tcl_GetString(dataVarObj), 0);
+
+			// Need to set a boolean result to return to the caller
+			Tcl_SetObjResult (interp, Tcl_NewBooleanObj (1));
 		} else {
 			if (Tcl_SetVar2Ex (interp, Tcl_GetString (dataVarObj), NULL, zsc->dataObj, TCL_LEAVE_ERR_MSG) == NULL) {
 				ckfree (zsc);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1532,7 +1532,7 @@ zootcl_get_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZOOAP
 			Tcl_SetObjResult (interp, Tcl_NewBooleanObj (1));
 		}
 
-		if (zootcl_stat_to_array (interp, statArray, stat) == TCL_ERROR) {
+		if (statArray && zootcl_stat_to_array (interp, statArray, stat) == TCL_ERROR) {
 			ckfree (stat);
 			return TCL_ERROR;
 		}

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1945,25 +1945,11 @@ zootcl_delete_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], ZO
 	}
 
 	if (callbackObj == NULL) {
-		zootcl_syncCallbackContext *zsc = (zootcl_syncCallbackContext *)ckalloc (sizeof (zootcl_syncCallbackContext));
-		zsc->zo = zo;
-		zsc->syncDone = 0;
-		status = zoo_adelete (zh, path, version, zootcl_sync_void_completion_callback, zsc);
+		// synchronous delete
+		status = zoo_delete(zh, path, version);
 		if (status != ZOK) {
-			ckfree (zsc);
 			return zootcl_set_tcl_return_code (interp, status);
 		}
-
-		if (zootcl_wait (zo, zsc) == TCL_ERROR) {
-			ckfree (zsc);
-			return TCL_ERROR;
-		}
-		status = zsc->rc;
-		if (status != ZOK) {
-			ckfree (zsc);
-			return zootcl_set_tcl_return_code (interp, status);
-		}
-		ckfree (zsc);
 	} else {
 		zootcl_callbackContext *ztc = (zootcl_callbackContext *)ckalloc (sizeof (zootcl_callbackContext));
 		ztc->callbackObj = callbackObj;

--- a/generic/zookeepertcl.h
+++ b/generic/zookeepertcl.h
@@ -31,7 +31,6 @@ typedef struct zootcl_objectClientData
 	Tcl_Command cmdToken;
 	Tcl_Channel channel;
 	int currentFD;
-	int closed;
 	Tcl_Obj *initCallbackObj; // handle callbacks from zookeeper_init callback function
 } zootcl_objectClientData;
 

--- a/generic/zookeepertcl.h
+++ b/generic/zookeepertcl.h
@@ -31,6 +31,7 @@ typedef struct zootcl_objectClientData
 	Tcl_Command cmdToken;
 	Tcl_Channel channel;
 	int currentFD;
+	int closed;
 	Tcl_Obj *initCallbackObj; // handle callbacks from zookeeper_init callback function
 } zootcl_objectClientData;
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,34 @@
+# `zookeepertcl` Unit Tests
+
+This folder contains unit tests for the `zookeepertcl` library.  It has tests for the Zookeeper API, watch callbacks and some of the `zookeepertcl` Tcl procs created in the `zookeeper` namespace.  Rather than mocking Zookeeper interaction, these unit tests communicate with an actual Zookeeper server / cluster.  Be warned, though, that the unit tests themselves do not setup a Zookeeper server / cluster: this must be done prior to executing the tests.  In addition, these tests impose an additional constraint that running any of the unit tests *must* be done through the `all.tcl` file, which takes some command line arguments: 
+
+- `zkHostString`: defaults to `localhost:2181`, this is the host string used for connecting to Zookeeper.  
+- `zkTestRoot`: defaults to `/zktcl_test`, this is the root znode which will contain all the data used by the unit tests.  Prior to running the unit tests this path is deleted and re-created.  Using a root path for any unit test data allows for a quick cleanup of any znodes created during testing.  While the unit tests themselves attempt to delete any nodes they create, in the case of an error this might not happen, so it is useful in that case to have any test data contained under a known root path.
+- `zkDebugLevel`: defaults to `none` and controls the debug level output by the library to `stderr`
+- `zkTimeout`: defaults to `3000` and sets the millisecond timeout for connecting to Zookeeper
+- `zkSyncTimeout`: defaults to `1500` milliseconds, this controls how long the unit tests for watch callbacks will wait before timing out
+- `testDebugLevel`: defaults to `0` and controls the Tcl test debug level 
+- `testFiles`: defaults to `*.test` and controls which test files to run unit tests from
+- `testMatch`: defaults to `*` and controls which test cases in the `testFiles` specified to actually run
+- `testSkip`: defaults to `""` and controls which test cases in the `testFiles` specified to skip over
+- `testVerbosity`: defaults to `body error` and controls the verbosity of Tcl test
+
+## Examples of Usage
+
+Running all the tests: 
+
+```
+tclsh all.tcl -zkHostString "server1.example.com:2181,server2.example.com:2181,server3.example.com"
+```
+
+Running only the API tests:
+
+```
+tclsh all.tcl -zkHostString "server1.example.com:2181,server2.example.com:2181,server3.example.com" -testFiles api.test
+```
+
+Running only the `get` watch tests:
+
+```
+tclsh all.tcl -zkHostString "server1.example.com:2181,server2.example.com:2181,server3.example.com" -testFiles watches.test -testMatch "get_*"
+```

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -13,9 +13,9 @@
 package require cmdline
 package require zookeeper
 
-proc connect_to_zookeeper {} {
+proc connect_to_zookeeper {{zkObjectName zk}} {
     zookeeper::zookeeper debug_level $::params(zkDebugLevel)
-    zookeeper::zookeeper init zk $::params(zkHostString) $::params(zkTimeout) -async init_callback
+    zookeeper::zookeeper init $zkObjectName $::params(zkHostString) $::params(zkTimeout) -async init_callback
     after $::params(zkTimeout) {set ::connected 0}
     vwait ::connected
 

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -35,9 +35,11 @@ proc main {argv} {
 	{skip.arg "" "List of patterns to determine whether a test should be skipped"}
 	{testDebugLevel.arg 0 "Test debug level"}
 	{testFiles.arg "*.test" "List of patterns to determine what test files to evaluate"}
+	{testMatch.arg "*" "List of patterns to determine which test cases should be run"}
 	{testVerbosity.arg "body error" "Type of output verbosity"}
 	{zkDebugLevel.arg "none" "debug_level to set in the zookeepertcl library during the tests"}
 	{zkHostString.arg "localhost:2181" "Zookeeper connection string used for running tests"}
+	{zkSyncTimeout.arg 1500 "Async callback timeout to ensure async tests cannot hang indefinitely"}
 	{zkTimeout.arg 3000 "Connection timeout in milliseconds"}
     } 
 
@@ -55,6 +57,7 @@ proc main {argv} {
     tcltest::configure -debug $::params(testDebugLevel)
     tcltest::configure -verbose $::params(testVerbosity)
     tcltest::configure -file $::params(testFiles)
+    tcltest::configure -match $::params(testMatch)
     tcltest::configure -skip $::params(skip)
 
     connect_to_zookeeper

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -32,10 +32,10 @@ proc init_callback {iDict} {
 proc main {argv} {
     set usage ": $::argv0 ?options?"
     set options {
-	{skip.arg "" "List of patterns to determine whether a test should be skipped"}
 	{testDebugLevel.arg 0 "Test debug level"}
 	{testFiles.arg "*.test" "List of patterns to determine what test files to evaluate"}
 	{testMatch.arg "*" "List of patterns to determine which test cases should be run"}
+	{testSkip.arg "" "List of patterns to determine whether a test should be skipped"}
 	{testVerbosity.arg "body error" "Type of output verbosity"}
 	{zkDebugLevel.arg "none" "debug_level to set in the zookeepertcl library during the tests"}
 	{zkHostString.arg "localhost:2181" "Zookeeper connection string used for running tests"}
@@ -58,7 +58,7 @@ proc main {argv} {
     tcltest::configure -verbose $::params(testVerbosity)
     tcltest::configure -file $::params(testFiles)
     tcltest::configure -match $::params(testMatch)
-    tcltest::configure -skip $::params(skip)
+    tcltest::configure -skip $::params(testSkip)
 
     connect_to_zookeeper
 

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -10,10 +10,59 @@
 # See the file "license.terms" for information on usage and redistribution
 # of this file, and for a DISCLAIMER OF ALL WARRANTIES.
 
-set tcltestVersion [package require tcltest]
-namespace import -force tcltest::*
+package require cmdline
+package require zookeeper
 
-tcltest::testsDirectory [file dir [info script]]
-tcltest::runAllTests
+proc connect_to_zookeeper {} {
+    zookeeper::zookeeper debug_level $::params(zkDebugLevel)
+    zookeeper::zookeeper init zk $::params(zkHostString) $::params(zkTimeout) -async init_callback
+    after $::params(zkTimeout) {set ::connected 0} 
+    vwait ::connected
 
-return
+    if {!$::connected} {
+	puts stderr "Could not connect to $::params(zkHostString)"
+	exit 1
+    }
+}
+
+proc init_callback {iDict} {
+    set ::connected 1
+}
+
+proc main {argv} {
+    set usage ": $::argv0 ?options?"
+    set options {
+	{skip.arg "" "List of patterns to determine whether a test should be skipped"}
+	{testDebugLevel.arg 0 "Test debug level"}
+	{testFiles.arg "*.test" "List of patterns to determine what test files to evaluate"}
+	{testVerbosity.arg "body error" "Type of output verbosity"}
+	{zkDebugLevel.arg "none" "debug_level to set in the zookeepertcl library during the tests"}
+	{zkHostString.arg "localhost:2181" "Zookeeper connection string used for running tests"}
+	{zkTimeout.arg 3000 "Connection timeout in milliseconds"}
+    } 
+
+    try {
+	array set ::params [::cmdline::getoptions argv $options $usage]
+    } on error {result options} {
+	puts stderr $result
+	exit 1
+    }
+
+    set tcltestVersion [package require tcltest]
+    namespace import -force tcltest::*
+
+    tcltest::configure -singleproc true; # use a singleproc so zk object can be shared
+    tcltest::configure -debug $::params(testDebugLevel)
+    tcltest::configure -verbose $::params(testVerbosity)
+    tcltest::configure -file $::params(testFiles)
+    tcltest::configure -skip $::params(skip)
+
+    connect_to_zookeeper
+
+    tcltest::testsDirectory [file dir [info script]]
+    tcltest::runAllTests
+}
+
+main $argv
+
+# vim: set ts=8 sw=4 sts=4 noet :

--- a/tests/api.test
+++ b/tests/api.test
@@ -39,6 +39,32 @@ proc delete_async {dDict} {
     set ::deleteAsync $dDict
 }
 
+proc stat_array_valid {_statArray} {
+    upvar $_statArray statArray
+
+    set statKeys {
+        aversion
+        ctime
+        cversion
+        czxid
+        dataLength
+        ephemeralOwner
+        mtime
+        mzxid
+        numChildren
+        pzxid
+        version
+    }
+
+    foreach statKey $statKeys {
+        if {![info exists statArray($statKey)]} {
+            return 0
+        }
+    }
+
+    return 1
+}
+
 #
 #
 # CREATE
@@ -179,7 +205,8 @@ test get_sync_normal {
     zk create $newNode -value getData
 
     set data [zk get $newNode -version gVersion] 
-    return [expr {$data eq "getData"}]
+    set data2 [zk get $newNode]
+    return [expr {$data eq "getData" && $data2 eq "getData"}]
 } -cleanup {
     zk delete $newNode $gVersion
 } -result 1
@@ -212,6 +239,37 @@ test get_data_flag_with_data {
 } -cleanup {
     zk delete $newNode $gVersion
 } -result 1
+
+test get_sync_stat_option_node_exists {
+    Test get's -stat option and make sure it contains all expected
+    values for a node that exists  
+} -setup {
+    array unset gStat
+} -body {
+    set nodePath [file join $::params(zkTestRoot) getStatOption]
+    zk create $nodePath
+
+    zk get $nodePath -stat gStat
+    return [stat_array_valid gStat]
+} -cleanup {
+    zk delete $nodePath $gStat(version)
+} -result 1
+
+test get_sync_stat_option_node_does_not_exist {
+    Test get's -stat option and make sure it does not set a stat
+    array for a node that does not exist
+} -setup {
+    array unset gStat
+} -body {
+    set nodePath [file join $::params(zkTestRoot) getStatOptionNoNode]
+    try {
+      zk get $nodePath -stat gStat
+    } on error {} {
+
+    } finally {
+      return [info exists gStat]
+    }
+} -result 0
 
 test get_data_flag_no_data {
     test get using the -data flag for a znode with no data
@@ -291,6 +349,36 @@ test exists_sync_version_option {
 } -cleanup {
     zk delete $eNodePath $eVersion
 } -result 1
+
+test exists_sync_stat_option_node_exists {
+    Test the -stat option to exists and make sure it agrees with
+    the data returned with the -version options and that it contains
+    all keys specified in the documentation for a node that exists
+} -setup {
+    array unset eStat
+} -body {
+    set eNodePath [file join $::params(zkTestRoot) existsStat]
+    zk create $eNodePath
+
+    zk exists $eNodePath -stat eStat
+    zk exists $eNodePath -version eVersion
+
+    return [expr {[stat_array_valid eStat] && $eStat(version) == $eVersion}]
+} -cleanup {
+    zk delete $eNodePath $eVersion
+} -result 1
+
+test exists_sync_stat_option_node_does_not_exist {
+    Test the -stat option to exists for a node that does not exist and
+    make sure the array is empty
+} -setup {
+    array unset eStat
+} -body {
+    set eNodePath [file join $::params(zkTestRoot) existsStatNoNode]
+
+    zk exists $eNodePath -stat eStat
+    return [info exists eStat]
+} -result 0
 
 test exists_deleted_node_sync {
     check for the existence of a node that does not exist in sync mode

--- a/tests/api.test
+++ b/tests/api.test
@@ -10,7 +10,9 @@ proc create_async {cDict} {
 
 
 #
-# CREATE
+#
+# API TESTS
+#
 #
 test create_sync {create a node and get its value} -body {
     set newNodeValue testingValueSync
@@ -83,6 +85,55 @@ test create_ephemeral_node {
 
     return [zk exists $eNodePath]
 } -result 0
+
+test create_sequential_node {
+    create a sequential node and verify that it has the right number of digits
+    which, according to the Zookeeper documentation, is 10, i.e., %010d
+} -body {
+    set sNodePath [file join / createSeq_]
+    set sNodePath [zk create $sNodePath -sequence]
+    
+    set relativeName [lindex [file split $sNodePath] end]
+    set numPart [lindex [split $relativeName _] end]
+    return [string length $numPart]
+} -cleanup {
+    # create does not respect chroot when it is used
+    # so have to compensate for this by being explicit 
+    # in specifying the path of the node to delete
+    zk delete [file join / $relativeName] -1
+} -result 10
+
+test create_numerous_sequential_nodes {
+    create many sequential nodes and verify that they only exhibit
+    monotonic sequence numbers
+} -body {
+    set sNodeBase [file join / createSeqs_]
+    set seqNums [list]
+    for {set i 0} {$i < 10} {incr i} {
+	set sPath [zk create $sNodeBase -sequence -ephemeral]
+	set sPath [lindex [file split $sPath] end]
+	set seqNum [lindex [split $sPath _] end]
+	lappend seqNums [scan $seqNum %d]
+    }
+
+    return [expr {$seqNums eq [lsort -integer $seqNums]}]
+} -result 1
+
+test exists_created_node_sync {
+    create a node and check for its existence in sync mode
+}
+
+test exists_created_node_async {
+    create a node and check for its existence in async mode
+}
+
+test exists_deleted_node_sync {
+
+}
+
+test exists_deleted_node_async {
+
+}
 
 cleanupTests
 

--- a/tests/api.test
+++ b/tests/api.test
@@ -22,6 +22,16 @@ test create_sync {create a node and get its value} -body {
     zk delete $newNodePath $nodeVersion
 } -result testingValueSync
 
+test create_sync_null_data {create a node with no data} -body {
+    set newNodeValue testingValueSync
+    set newNodePath [file join / testCreateSyncNoData]
+    zk create $newNodePath 
+
+    return [zk get $newNodePath -version nodeVersion]
+} -cleanup {
+    zk delete $newNodePath $nodeVersion
+} -result ""
+
 test create_async {create a node using async and get its value} -body {
     set newNodeValue testingValueAsync
     set newNodePath [file join / testCreateAsync]
@@ -61,6 +71,18 @@ test create_node_twice_async {
 } -cleanup {
     zk delete $newNodePath -1
 } -result ZNODEEXISTS
+
+test create_ephemeral_node {
+    create an ephemeral node, disconnect and verify that it no longer exists
+} -body {
+    set eNodePath [file join / createEphem]
+    zk create $eNodePath -ephemeral
+
+    zk destroy
+    connect_to_zookeeper
+
+    return [zk exists $eNodePath]
+} -result 0
 
 cleanupTests
 

--- a/tests/api.test
+++ b/tests/api.test
@@ -209,9 +209,9 @@ test get_data_flag_no_data {
     zk create $newNode 
 
     set res [zk get $newNode -version gVersion -data gData]
-    return [expr {!$res && ![info exists gData]}]
+    return [expr {$res && ![info exists gData]}]
 } -cleanup {
-    zk delete $newNode -1
+    zk delete $newNode $gVersion
 } -result 1
 
 test get_sync_znode_madeup {

--- a/tests/api.test
+++ b/tests/api.test
@@ -8,6 +8,7 @@
 ##  - CHILDREN
 ##  - SET
 ##  - DELETE
+##  - DESTROY
 ##
 package require tcltest
 namespace import ::tcltest::*
@@ -725,6 +726,56 @@ test delete_async_madeup_znode {
 
     return [dict get $::deleteAsync status]
 } -result ZNONODE
+
+#
+#
+# DESTROY
+#
+#
+test destroy_and_recreate_zookeeper_object {
+    Make sure calling destroy and then recreating the object multiple times
+    does not cause any errors
+} -body {
+    for {set i 0} {$i < 3} {incr i} {
+        zk destroy
+        connect_to_zookeeper
+    }
+    return [expr {[zk state] eq "connected"}]
+} -result 1
+
+test destroy_before_event_can_be_invoked_for_async_call {
+    Make an async call on the Zookeeper object and then delete immediately
+    before the event has the chance to fire
+} -body {
+    zk get $::params(zkTestRoot) -async get_async
+    zk set $::params(zkTestRoot) test -1 -async get_async
+    zk exists $::params(zkTestRoot) -async get_async
+    zk destroy
+
+    set getTimeout [after $::params(zkSyncTimeout) {set ::getAsync ""}]
+    vwait ::getAsync
+    after cancel $getTimeout
+
+    connect_to_zookeeper 
+
+    return $::getAsync
+} -result ""
+
+test destroy_should_not_affect_after_events_not_related_to_it {
+    When destroy is called, all events for the object should be deleted but
+    after events created by anything else should not be deleted
+} -body {
+    zk get $::params(zkTestRoot) -async get_async
+    set getTimeout [after $::params(zkSyncTimeout) {set ::getAsync ""}]
+
+    # when an after event does not exist, after info throws an errror
+    after info $getTimeout
+    after cancel $getTimeout
+
+    return 1
+} -cleanup {
+    connect_to_zookeeper
+} -result 1
 
 cleanupTests
 

--- a/tests/api.test
+++ b/tests/api.test
@@ -489,8 +489,41 @@ test set_async_version_wrong {
     zk delete $path -1
 } -result ZBADVERSION 
 
+test set_sync_verify_version_changes {
+    Ensure that the version of a znode changes when its data changes (sync version)
+} -body {
+    set setPath [file join $::params(zkTestRoot) setSyncVersion]
+    zk create $setPath
+    zk get $setPath -version nodeVersionStart
+
+    zk set $setPath newData $nodeVersionStart
+    zk get $setPath -version nodeVersionAfterSet
+
+    return [expr {$nodeVersionAfterSet > $nodeVersionStart}]
+} -cleanup {
+    zk delete $setPath $nodeVersionAfterSet
+} -result 1
+
+test set_async_verify_version_changes {
+    Ensure that the version of a znode changes when its data changes (async version)
+} -body {
+    set setPath [file join $::params(zkTestRoot) setAsyncVersion]
+    zk create $setPath
+    zk get $setPath -version nodeVersionStart
+
+    zk set $setPath newData $nodeVersionStart -async set_async
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::async {version -1}}]
+    vwait ::setAsync
+    after cancel $asyncTimeout
+
+    set nodeVersionAfterSet [dict get $::setAsync version]
+    return [expr {$nodeVersionAfterSet > $nodeVersionStart}]
+} -cleanup {
+    zk delete $setPath $nodeVersionAfterSet
+} -result 1
+
 test set_sync_madeup_znode {
-    try to set the data for a znode in sync mode whose path does not exist
+    Try to set the data for a znode in sync mode whose path does not exist
 } -body {
     catch {zk set [file join $::params(zkTestRoot) madeUp] data -1}
     puts $::errorCode

--- a/tests/api.test
+++ b/tests/api.test
@@ -11,7 +11,7 @@ proc create_async {cDict} {
 
 #
 #
-# API TESTS
+# CREATE
 #
 #
 test create_sync {create a node and get its value} -body {
@@ -119,6 +119,11 @@ test create_numerous_sequential_nodes {
     return [expr {$seqNums eq [lsort -integer $seqNums]}]
 } -result 1
 
+#
+#
+# EXISTS
+#
+#
 test exists_created_node_sync {
     create a node and check for its existence in sync mode
 }
@@ -134,6 +139,24 @@ test exists_deleted_node_sync {
 test exists_deleted_node_async {
 
 }
+
+#
+#
+# CHILDREN
+#
+#
+
+#
+#
+# SET
+#
+#
+
+#
+#
+# DELETE
+#
+#
 
 cleanupTests
 

--- a/tests/api.test
+++ b/tests/api.test
@@ -8,6 +8,10 @@ proc create_async {cDict} {
     set ::createAsync $cDict
 }
 
+proc get_async {gDict} {
+    set ::getAsync $gDict
+}
+
 proc exists_async {eDict} {
     set ::existsAsync $eDict
 }
@@ -42,7 +46,7 @@ test create_sync {create a node and get its value} -body {
 test create_sync_null_data {create a node with no data} -body {
     set newNodeValue testingValueSync
     set newNodePath [file join / testCreateSyncNoData]
-    zk create $newNodePath 
+    zk create $newNodePath
 
     return [zk get $newNodePath -version nodeVersion]
 } -cleanup {
@@ -54,7 +58,10 @@ test create_async {create a node using async and get its value} -body {
     set newNodePath [file join / testCreateAsync]
     zk create $newNodePath -value $newNodeValue -async create_async
 
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::createAsync {status TIMEOUT}}]
     vwait ::createAsync
+    after cancel $asyncTimeout
+
     return [dict get $::createAsync status]
 } -cleanup {
     zk delete $newNodePath $nodeVersion
@@ -83,7 +90,11 @@ test create_node_twice_async {
 
     # try it again even though it already exists
     zk create $newNodePath -value $newNodeValue -async create_async
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::createAsync {status TIMEOUT}}]
     vwait ::createAsync
+    after cancel $asyncTimeout
+
     return [dict get $::createAsync status]
 } -cleanup {
     zk delete $newNodePath -1
@@ -100,6 +111,17 @@ test create_ephemeral_node {
 
     return [zk exists $eNodePath]
 } -result 0
+
+test create_child_of_ephemeral_node {
+    try to illegally create a child for an ephemeral node
+} -body {
+    set eNodePath [file join / createEphemChild]
+    zk create $eNodePath -ephemeral
+
+    set eNodeChildPath [file join $eNodePath child]
+    catch {zk create $eNodeChildPath}
+    puts $::errorCode
+} -output ZNOCHILDRENFOREPHEMERALS -match regexp
 
 test create_sequential_node {
     create a sequential node and verify that it has the right number of digits
@@ -136,6 +158,83 @@ test create_numerous_sequential_nodes {
 
 #
 #
+# GET
+#
+#
+test get_sync_normal {
+    test get call in sync mode for node known to exist
+} -body {
+    set newNode [file join / getNode]
+    zk create $newNode -value getData
+
+    set data [zk get $newNode -version gVersion] 
+    return [expr {$data eq "getData"}]
+} -cleanup {
+    zk delete $newNode $gVersion
+} -result 1
+
+test get_async_normal {
+    test get call in async mode for node known to exist
+} -body {
+    set newNode [file join / getNode]
+    zk create $newNode -value getData
+
+    zk get $newNode -async get_async
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::getAsync {status TIMEOUT}}]
+    vwait ::getAsync
+    after cancel $asyncTimeout
+
+    return [expr {[dict get $::getAsync data] eq "getData"}]
+} -cleanup {
+    zk delete $newNode [dict get $::getAsync version]
+} -result 1
+
+test get_data_flag_with_data {
+    test get using the -data flag for a znode with data
+} -body {
+    set newNode [file join / getNode]
+    zk create $newNode -value getData
+
+    set res [zk get $newNode -version gVersion -data gData]
+    return [expr {$res && $gData eq "getData"}]
+} -cleanup {
+    zk delete $newNode $gVersion
+} -result 1
+
+test get_data_flag_no_data {
+    test get using the -data flag for a znode with no data
+} -body {
+    set newNode [file join / getNode]
+    zk create $newNode 
+
+    set res [zk get $newNode -version gVersion -data gData]
+    return [expr {!$res && ![info exists gData]}]
+} -cleanup {
+    zk delete $newNode -1
+} -result 1
+
+test get_sync_znode_madeup {
+    test get in sync mode for a znode whose path does not exist 
+} -body {
+    catch {zk get /madeUp}
+    puts $::errorCode
+} -output ZNONODE -match regexp
+
+test get_async_znode_madeup {
+    test get in async mode for a znode whose path does not exist
+} -body {
+    zk get /madeUp -async get_async
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::getAsync {status TIMEOUT}}]
+    vwait ::getAsync
+    after cancel $asyncTimeout
+
+    return [dict get $::getAsync status]
+} -result ZNONODE
+
+#
+#
 # EXISTS
 #
 #
@@ -157,12 +256,30 @@ test exists_created_node_async {
     zk create $eNodePath 
 
     zk exists $eNodePath -async exists_async 
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::existsAsync {status TIMEOUT}}]
     vwait ::existsAsync
+    after cancel $asyncTimeout
 
     return [dict get $::existsAsync status]
 } -cleanup {
     zk delete $eNodePath [dict get $::existsAsync version]
 } -result ZOK
+
+test exists_sync_version_option {
+    test the -version option to exists and make sure it agrees
+    with the version returned by the get API call
+} -body {
+    set eNodePath [file join / existsVersion]
+    zk create $eNodePath
+
+    zk get $eNodePath -version gVersion
+    zk exists $eNodePath -version eVersion
+
+    return [expr {$gVersion == $eVersion}]
+} -cleanup {
+    zk delete $eNodePath $eVersion
+} -result 1
 
 test exists_deleted_node_sync {
     check for the existence of a node that does not exist in sync mode
@@ -188,7 +305,10 @@ test exists_deleted_node_async {
     zk delete $eNodePath -1
 
     zk exists $eNodePath -async exists_async 
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::existsAsync {status TIMEOUT}}]
     vwait ::existsAsync
+    after cancel $asyncTimeout
 
     return [dict get $::existsAsync status]
 } -result ZNONODE
@@ -215,6 +335,7 @@ test children_sync_normal {
     foreach child $children {
 	zk delete [file join $parentPath $child] -1
     }
+    zk delete $parentPath -1
 } -result 1
 
 test children_async_normal {
@@ -229,20 +350,63 @@ test children_async_normal {
     }
 
     zk children $parentPath -async children_async
+    
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::childrenAsync {data TIMEOUT}}]
     vwait ::childrenAsync
+    after cancel $asyncTimeout
+
+    set zkChildren [dict get $::childrenAsync data]
+    return [expr {[lsort -integer $zkChildren] eq $children}]
 } -cleanup {
     foreach child $children {
 	zk delete [file join $parentPath $child] -1
     }
+    zk delete $parentPath -1
 } -result 1
 
 test children_sync_no_children {
     check for children in sync mode on a znode that has no children
-}
+} -body {
+    set noChildrenPath [file join / noChildren]
+    zk create $noChildrenPath
+
+    set children [zk children $noChildrenPath]
+    return [expr {$children eq {}}]     
+} -cleanup {
+    zk delete $noChildrenPath -1
+} -result 1
 
 test children_async_no_children {
     check for children in async mode on a znode that has no children
-} 
+} -body {
+    set noChildrenPath [file join / noChildren]
+    zk create $noChildrenPath
+
+    zk children $noChildrenPath -async children_async
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::childrenAsync {data TIMEOUT}}]
+    vwait ::childrenAsync
+    after cancel $asyncTimeout
+
+    return [expr {[dict get $::childrenAsync data] eq {}}]
+} -cleanup {
+    zk delete $noChildrenPath -1
+} -result 1
+
+test children_sync_znode_not_exists {
+    try to get a list of children for a znode that does not exist
+} -body {
+    return [zk children /doesNotExist]
+} -result {}
+
+test children_async_znode_not_exists {
+    zk children /doesNotExist -async children_async
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::childrenAsync {data TIMEOUT}}]
+    vwait ::childrenAsync
+    after cancel $asyncTimeout
+
+    return [dict get $::childrenAsync data]
+} -result {}
 
 #
 #
@@ -250,28 +414,88 @@ test children_async_no_children {
 #
 #
 test set_sync_normal {
+    set the data for a znode in sync mode
+} -body {
+    set path [file join / setSyncNormal]
+    zk create $path -value start
+    set beforeSet [zk get $path -version startVersion]
 
-}
+    zk set $path end $startVersion
+    set afterSet [zk get $path -version endVersion]
+
+    return [expr {$beforeSet eq "start" && $afterSet eq "end" && $endVersion > $startVersion}]
+} -cleanup {
+    zk delete $path $endVersion
+} -result 1
 
 test set_async_normal {
+    set the data for a znode in async mode
+} -body {
+    set path [file join / setSyncNormal]
+    zk create $path -value start
+    set beforeSet [zk get $path -version startVersion]
 
-}
+    zk set $path end $startVersion -async set_async 
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::setAsync {status TIMEOUT}}]
+    vwait ::setAsync
+    after cancel $asyncTimeout
+
+    set asyncSetVersion [dict get $::setAsync version]
+    set afterSet [zk get $path -version endVersion]
+    return [expr {$beforeSet eq "start" && $afterSet eq "end" && \
+		  $asyncSetVersion == $endVersion && $endVersion > $startVersion}]
+} -cleanup {
+    zk delete $path $endVersion
+} -result 1
 
 test set_sync_version_wrong {
+    try to set the data for a znode in sync mode with a bad version number
+} -body {
+    set path [file join / setSyncNormal]
+    zk create $path -value start
+    set beforeSet [zk get $path -version startVersion]
 
-}
+    catch {zk set $path end [expr {$startVersion + 1}]}
+    puts $::errorCode
+} -cleanup {
+    zk delete $path -1
+} -output ZBADVERSION -match regexp
 
 test set_async_version_wrong {
+    try to set the data for a znode in async mode with a bad version number
+} -body {
+    set path [file join / setSyncNormal]
+    zk create $path -value start
+    set beforeSet [zk get $path -version startVersion]
 
-}
+    zk set $path end [expr {$startVersion + 1}] -async set_async
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::setAsync {status TIMEOUT}}]
+    vwait ::setAsync
+    after cancel $asyncTimeout
+
+    return [dict get $::setAsync status]
+} -cleanup {
+    zk delete $path -1
+} -result ZBADVERSION 
 
 test set_sync_madeup_znode {
-
-}
+    try to set the data for a znode in sync mode whose path does not exist
+} -body {
+    catch {zk set /madeUp data -1}
+    puts $::errorCode
+} -output ZNONODE -match regexp
 
 test set_async_madeup_znode {
+    try to set the data for a znode in async mode whose path does not exist
+} -body {
 
-}
+    zk set /madeUp data -1 -async set_async
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::setAsync {status TIMEOUT}}]
+    vwait ::setAsync
+    after cancel $asyncTimeout
+
+    return [dict get $::setAsync status]
+} -result ZNONODE
 
 #
 #
@@ -279,28 +503,96 @@ test set_async_madeup_znode {
 #
 #
 test delete_sync_normal {
+    delete a znode in sync mode
+} -body {
+    set newNode [file join / deleteThis]
+    zk create $newNode
 
-}
+    zk delete $newNode -1
+    set deleteNoVersion [expr {![zk exists $newNode]}]
+
+    zk create $newNode
+    zk get $newNode -version dVersion
+    zk delete $newNode $dVersion
+    set deleteVersion [expr {![zk exists $newNode]}]
+
+    return [expr {$deleteNoVersion && $deleteVersion}]
+} -result 1
 
 test delete_async_normal {
+    delete a znode in async mode
+} -body {
+    set newNode [file join / deleteThis]
 
-}
+    zk create $newNode
+    zk delete $newNode -1 -async delete_async
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::deleteAsync {status TIMEOUT}}]
+    vwait ::deleteAsync
+    after cancel $asyncTimeout
+    set deleteNoVersion [expr {![zk exists $newNode]}]
+
+    zk create $newNode
+    zk get $newNode -version dVersion
+    zk delete $newNode $dVersion -async delete_async
+
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::deleteAsync {status TIMEOUT}}]
+    vwait ::deleteAsync
+    after cancel $asyncTimeout
+    set deleteVersion [expr {![zk exists $newNode]}]
+
+    return [expr {$deleteNoVersion && $deleteVersion}]
+} -result 1
 
 test delete_sync_version_wrong {
+    try to delete a znode in sync mode with an incorrect version
+} -body {
+    set newNode [file join / deleteThis]
+    zk create $newNode
+    zk get $newNode -version dVersion
 
-}
+    catch {zk delete $newNode [expr {$dVersion + 1}]}
+    puts $::errorCode
+} -cleanup {
+    zk delete $newNode $dVersion
+} -output ZBADVERSION -match regexp
 
 test delete_async_version_wrong {
+    try to delete a znode in async mode with an incorrect version
+} -body {
 
-}
+    set newNode [file join / deleteThis]
+    zk create $newNode
+    zk get $newNode -version dVersion
+
+    zk delete $newNode [expr {$dVersion + 1}] -async delete_async
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::deleteAsync {status TIMEOUT}}]
+    vwait ::deleteAsync
+    after cancel $asyncTimeout
+
+    return [dict get $::deleteAsync status]
+} -cleanup {
+    zk delete $newNode $dVersion
+} -result ZBADVERSION 
 
 test delete_sync_madeup_znode {
-
-}
+    try to delete a znode in sync mode whose path does not exist
+} -body {
+    catch {zk delete /madeUp -1}
+    puts $::errorCode
+} -output ZNONODE -match regexp
 
 test delete_async_madeup_znode {
+    try to delete a znode in async mode whose path does not exist
+} -body {
+    zk delete /madeUp -1 -async delete_async
 
-}
+    set asyncTimeout [after $::params(zkSyncTimeout) {set ::deleteAsync {status TIMEOUT}}]
+    vwait ::deleteAsync
+    after cancel $asyncTimeout
+
+    return [dict get $::deleteAsync status]
+} -result ZNONODE
 
 cleanupTests
 

--- a/tests/api.test
+++ b/tests/api.test
@@ -1,0 +1,67 @@
+package require tcltest
+namespace import ::tcltest::*
+
+#
+# HELPER PROCS 
+#
+proc create_async {cDict} {
+    set ::createAsync $cDict
+}
+
+
+#
+# CREATE
+#
+test create_sync {create a node and get its value} -body {
+    set newNodeValue testingValueSync
+    set newNodePath [file join / testCreateSync]
+    zk create $newNodePath -value $newNodeValue
+
+    return [zk get $newNodePath -version nodeVersion]
+} -cleanup {
+    zk delete $newNodePath $nodeVersion
+} -result testingValueSync
+
+test create_async {create a node using async and get its value} -body {
+    set newNodeValue testingValueAsync
+    set newNodePath [file join / testCreateAsync]
+    zk create $newNodePath -value $newNodeValue -async create_async
+
+    vwait ::createAsync
+    return [dict get $::createAsync status]
+} -cleanup {
+    zk delete $newNodePath $nodeVersion
+} -result ZOK
+
+test create_node_twice_sync {
+    create a node and then try to create it again
+} -body {
+    set newNodeValue createDup
+    set newNodePath [file join / createDup]
+    zk create $newNodePath -value $newNodeValue
+
+    # try it again even though it already exists
+    catch {zk create $newNodePath -value $newNodeValue} 
+    puts $::errorCode
+} -cleanup {
+    zk delete $newNodePath -1
+} -output "ZOOKEEPER ZNODEEXISTS {node exists}" -match regexp
+
+test create_node_twice_async {
+    create a node using async and then try to create it again
+} -body {
+    set newNodeValue createDup
+    set newNodePath [file join / createDup]
+    zk create $newNodePath -value $newNodeValue
+
+    # try it again even though it already exists
+    zk create $newNodePath -value $newNodeValue -async create_async
+    vwait ::createAsync
+    return [dict get $::createAsync status]
+} -cleanup {
+    zk delete $newNodePath -1
+} -result ZNODEEXISTS
+
+cleanupTests
+
+# vim: set ts=8 sw=4 sts=4 noet :

--- a/tests/api.test
+++ b/tests/api.test
@@ -337,14 +337,14 @@ test children_sync_normal {
 
     set children {0 1 2 3 4 5 6 7 8 9}
     foreach child $children {
-	zk create [file join $parentPath $child]	
+	      zk create [file join $parentPath $child]	
     }
 
     set zkChildren [lsort -integer [zk children $parentPath]]
     return [expr {$children eq $zkChildren}]
 } -cleanup {
     foreach child $children {
-	zk delete [file join $parentPath $child] -1
+	      zk delete [file join $parentPath $child] -1
     }
     zk delete $parentPath -1
 } -result 1

--- a/tests/api.test
+++ b/tests/api.test
@@ -1,3 +1,14 @@
+##
+##
+## api.test - Test the following Zookeeper API commands:
+##  
+##  - CREATE
+##  - GET
+##  - EXISTS
+##  - CHILDREN
+##  - SET
+##  - DELETE
+##
 package require tcltest
 namespace import ::tcltest::*
 

--- a/tests/api.test
+++ b/tests/api.test
@@ -46,7 +46,7 @@ proc delete_async {dDict} {
 #
 test create_sync {create a node and get its value} -body {
     set newNodeValue testingValueSync
-    set newNodePath [file join / testCreateSync]
+    set newNodePath [file join $::params(zkTestRoot) testCreateSync]
     zk create $newNodePath -value $newNodeValue
 
     return [zk get $newNodePath -version nodeVersion]
@@ -56,7 +56,7 @@ test create_sync {create a node and get its value} -body {
 
 test create_sync_null_data {create a node with no data} -body {
     set newNodeValue testingValueSync
-    set newNodePath [file join / testCreateSyncNoData]
+    set newNodePath [file join $::params(zkTestRoot) testCreateSyncNoData]
     zk create $newNodePath
 
     return [zk get $newNodePath -version nodeVersion]
@@ -66,7 +66,7 @@ test create_sync_null_data {create a node with no data} -body {
 
 test create_async {create a node using async and get its value} -body {
     set newNodeValue testingValueAsync
-    set newNodePath [file join / testCreateAsync]
+    set newNodePath [file join $::params(zkTestRoot) testCreateAsync]
     zk create $newNodePath -value $newNodeValue -async create_async
 
     set asyncTimeout [after $::params(zkSyncTimeout) {set ::createAsync {status TIMEOUT}}]
@@ -82,7 +82,7 @@ test create_node_twice_sync {
     create a node and then try to create it again
 } -body {
     set newNodeValue createDup
-    set newNodePath [file join / createDup]
+    set newNodePath [file join $::params(zkTestRoot) createDup]
     zk create $newNodePath -value $newNodeValue
 
     # try it again even though it already exists
@@ -96,7 +96,7 @@ test create_node_twice_async {
     create a node using async and then try to create it again
 } -body {
     set newNodeValue createDup
-    set newNodePath [file join / createDup]
+    set newNodePath [file join $::params(zkTestRoot) createDup]
     zk create $newNodePath -value $newNodeValue
 
     # try it again even though it already exists
@@ -114,7 +114,7 @@ test create_node_twice_async {
 test create_ephemeral_node {
     create an ephemeral node, disconnect and verify that it no longer exists
 } -body {
-    set eNodePath [file join / createEphem]
+    set eNodePath [file join $::params(zkTestRoot) createEphem]
     zk create $eNodePath -ephemeral
 
     zk destroy
@@ -126,7 +126,7 @@ test create_ephemeral_node {
 test create_child_of_ephemeral_node {
     try to illegally create a child for an ephemeral node
 } -body {
-    set eNodePath [file join / createEphemChild]
+    set eNodePath [file join $::params(zkTestRoot) createEphemChild]
     zk create $eNodePath -ephemeral
 
     set eNodeChildPath [file join $eNodePath child]
@@ -138,7 +138,7 @@ test create_sequential_node {
     create a sequential node and verify that it has the right number of digits
     which, according to the Zookeeper documentation, is 10, i.e., %010d
 } -body {
-    set sNodePath [file join / createSeq_]
+    set sNodePath [file join $::params(zkTestRoot) createSeq_]
     set sNodePath [zk create $sNodePath -sequence]
     
     set relativeName [lindex [file split $sNodePath] end]
@@ -148,20 +148,20 @@ test create_sequential_node {
     # create does not respect chroot when it is used
     # so have to compensate for this by being explicit 
     # in specifying the path of the node to delete
-    zk delete [file join / $relativeName] -1
+    zk delete [file join $::params(zkTestRoot) $relativeName] -1
 } -result 10
 
 test create_numerous_sequential_nodes {
     create many sequential nodes and verify that they only exhibit
     monotonic sequence numbers
 } -body {
-    set sNodeBase [file join / createSeqs_]
+    set sNodeBase [file join $::params(zkTestRoot) createSeqs_]
     set seqNums [list]
     for {set i 0} {$i < 10} {incr i} {
-	set sPath [zk create $sNodeBase -sequence -ephemeral]
-	set sPath [lindex [file split $sPath] end]
-	set seqNum [lindex [split $sPath _] end]
-	lappend seqNums [scan $seqNum %d]
+        set sPath [zk create $sNodeBase -sequence -ephemeral]
+        set sPath [lindex [file split $sPath] end]
+        set seqNum [lindex [split $sPath _] end]
+        lappend seqNums [scan $seqNum %d]
     }
 
     return [expr {$seqNums eq [lsort -integer $seqNums]}]
@@ -175,7 +175,7 @@ test create_numerous_sequential_nodes {
 test get_sync_normal {
     test get call in sync mode for node known to exist
 } -body {
-    set newNode [file join / getNode]
+    set newNode [file join $::params(zkTestRoot) getNode]
     zk create $newNode -value getData
 
     set data [zk get $newNode -version gVersion] 
@@ -187,7 +187,7 @@ test get_sync_normal {
 test get_async_normal {
     test get call in async mode for node known to exist
 } -body {
-    set newNode [file join / getNode]
+    set newNode [file join $::params(zkTestRoot) getNode]
     zk create $newNode -value getData
 
     zk get $newNode -async get_async
@@ -204,7 +204,7 @@ test get_async_normal {
 test get_data_flag_with_data {
     test get using the -data flag for a znode with data
 } -body {
-    set newNode [file join / getNode]
+    set newNode [file join $::params(zkTestRoot) getNode]
     zk create $newNode -value getData
 
     set res [zk get $newNode -version gVersion -data gData]
@@ -216,7 +216,7 @@ test get_data_flag_with_data {
 test get_data_flag_no_data {
     test get using the -data flag for a znode with no data
 } -body {
-    set newNode [file join / getNode]
+    set newNode [file join $::params(zkTestRoot) getNode]
     zk create $newNode 
 
     set res [zk get $newNode -version gVersion -data gData]
@@ -228,14 +228,14 @@ test get_data_flag_no_data {
 test get_sync_znode_madeup {
     test get in sync mode for a znode whose path does not exist 
 } -body {
-    catch {zk get /madeUp}
+    catch {zk get [file join $::params(zkTestRoot) madeUp]}
     puts $::errorCode
 } -output ZNONODE -match regexp
 
 test get_async_znode_madeup {
     test get in async mode for a znode whose path does not exist
 } -body {
-    zk get /madeUp -async get_async
+    zk get [file join $::params(zkTestRoot) madeUp] -async get_async
 
     set asyncTimeout [after $::params(zkSyncTimeout) {set ::getAsync {status TIMEOUT}}]
     vwait ::getAsync
@@ -252,7 +252,7 @@ test get_async_znode_madeup {
 test exists_created_node_sync {
     create a node and check for its existence in sync mode
 } -body {
-    set eNodePath [file join / createEphem]
+    set eNodePath [file join $::params(zkTestRoot) createEphem]
     zk create $eNodePath 
 
     zk exists $eNodePath -version nodeVersion
@@ -263,7 +263,7 @@ test exists_created_node_sync {
 test exists_created_node_async {
     create a node and check for its existence in async mode
 } -body {
-    set eNodePath [file join / createEphem]
+    set eNodePath [file join $::params(zkTestRoot) createEphem]
     zk create $eNodePath 
 
     zk exists $eNodePath -async exists_async 
@@ -281,7 +281,7 @@ test exists_sync_version_option {
     test the -version option to exists and make sure it agrees
     with the version returned by the get API call
 } -body {
-    set eNodePath [file join / existsVersion]
+    set eNodePath [file join $::params(zkTestRoot) existsVersion]
     zk create $eNodePath
 
     zk get $eNodePath -version gVersion
@@ -295,7 +295,7 @@ test exists_sync_version_option {
 test exists_deleted_node_sync {
     check for the existence of a node that does not exist in sync mode
 } -body {
-    set eNodePath [file join / createEphem]
+    set eNodePath [file join $::params(zkTestRoot) createEphem]
     zk create $eNodePath 
     zk delete $eNodePath -1
 
@@ -311,7 +311,7 @@ test exists_deleted_node_sync {
 test exists_deleted_node_async {
     check for the existence of a node that does not exist in async mode
 } -body {
-    set eNodePath [file join / createEphem]
+    set eNodePath [file join $::params(zkTestRoot) createEphem]
     zk create $eNodePath 
     zk delete $eNodePath -1
 
@@ -332,7 +332,7 @@ test exists_deleted_node_async {
 test children_sync_normal {
     create several children in sync mode and test for their existence
 } -body {
-    set parentPath [file join / children]
+    set parentPath [file join $::params(zkTestRoot) childrenSync]
     zk create $parentPath
 
     set children {0 1 2 3 4 5 6 7 8 9}
@@ -352,12 +352,12 @@ test children_sync_normal {
 test children_async_normal {
     create several children in async mode and test for their existence
 } -body {
-    set parentPath [file join / children]
+    set parentPath [file join $::params(zkTestRoot) childrenAsync]
     zk create $parentPath
 
     set children {0 1 2 3 4 5 6 7 8 9}
     foreach child $children {
-	zk create [file join $parentPath $child]	
+	      zk create [file join $parentPath $child]	
     }
 
     zk children $parentPath -async children_async
@@ -370,7 +370,7 @@ test children_async_normal {
     return [expr {[lsort -integer $zkChildren] eq $children}]
 } -cleanup {
     foreach child $children {
-	zk delete [file join $parentPath $child] -1
+	      zk delete [file join $parentPath $child] -1
     }
     zk delete $parentPath -1
 } -result 1
@@ -378,7 +378,7 @@ test children_async_normal {
 test children_sync_no_children {
     check for children in sync mode on a znode that has no children
 } -body {
-    set noChildrenPath [file join / noChildren]
+    set noChildrenPath [file join $::params(zkTestRoot) noChildren]
     zk create $noChildrenPath
 
     set children [zk children $noChildrenPath]
@@ -390,7 +390,7 @@ test children_sync_no_children {
 test children_async_no_children {
     check for children in async mode on a znode that has no children
 } -body {
-    set noChildrenPath [file join / noChildren]
+    set noChildrenPath [file join $::params(zkTestRoot) noChildren]
     zk create $noChildrenPath
 
     zk children $noChildrenPath -async children_async
@@ -406,11 +406,11 @@ test children_async_no_children {
 test children_sync_znode_not_exists {
     try to get a list of children for a znode that does not exist
 } -body {
-    return [zk children /doesNotExist]
+    return [zk children [file join $::params(zkTestRoot) doesNotExist]]
 } -result {}
 
 test children_async_znode_not_exists {
-    zk children /doesNotExist -async children_async
+    zk children [file join $::params(zkTestRoot) doesNotExist] -async children_async
 
     set asyncTimeout [after $::params(zkSyncTimeout) {set ::childrenAsync {data TIMEOUT}}]
     vwait ::childrenAsync
@@ -427,7 +427,7 @@ test children_async_znode_not_exists {
 test set_sync_normal {
     set the data for a znode in sync mode
 } -body {
-    set path [file join / setSyncNormal]
+    set path [file join $::params(zkTestRoot) setSyncNormal]
     zk create $path -value start
     set beforeSet [zk get $path -version startVersion]
 
@@ -442,7 +442,7 @@ test set_sync_normal {
 test set_async_normal {
     set the data for a znode in async mode
 } -body {
-    set path [file join / setSyncNormal]
+    set path [file join $::params(zkTestRoot) setSyncNormal]
     zk create $path -value start
     set beforeSet [zk get $path -version startVersion]
 
@@ -462,7 +462,7 @@ test set_async_normal {
 test set_sync_version_wrong {
     try to set the data for a znode in sync mode with a bad version number
 } -body {
-    set path [file join / setSyncNormal]
+    set path [file join $::params(zkTestRoot) setSyncNormal]
     zk create $path -value start
     set beforeSet [zk get $path -version startVersion]
 
@@ -475,7 +475,7 @@ test set_sync_version_wrong {
 test set_async_version_wrong {
     try to set the data for a znode in async mode with a bad version number
 } -body {
-    set path [file join / setSyncNormal]
+    set path [file join $::params(zkTestRoot) setSyncNormal]
     zk create $path -value start
     set beforeSet [zk get $path -version startVersion]
 
@@ -492,7 +492,7 @@ test set_async_version_wrong {
 test set_sync_madeup_znode {
     try to set the data for a znode in sync mode whose path does not exist
 } -body {
-    catch {zk set /madeUp data -1}
+    catch {zk set [file join $::params(zkTestRoot) madeUp] data -1}
     puts $::errorCode
 } -output ZNONODE -match regexp
 
@@ -500,7 +500,7 @@ test set_async_madeup_znode {
     try to set the data for a znode in async mode whose path does not exist
 } -body {
 
-    zk set /madeUp data -1 -async set_async
+    zk set [file join $::params(zkTestRoot) madeUp] data -1 -async set_async
     set asyncTimeout [after $::params(zkSyncTimeout) {set ::setAsync {status TIMEOUT}}]
     vwait ::setAsync
     after cancel $asyncTimeout
@@ -516,7 +516,7 @@ test set_async_madeup_znode {
 test delete_sync_normal {
     delete a znode in sync mode
 } -body {
-    set newNode [file join / deleteThis]
+    set newNode [file join $::params(zkTestRoot) deleteThis]
     zk create $newNode
 
     zk delete $newNode -1
@@ -533,7 +533,7 @@ test delete_sync_normal {
 test delete_async_normal {
     delete a znode in async mode
 } -body {
-    set newNode [file join / deleteThis]
+    set newNode [file join $::params(zkTestRoot) deleteThis]
 
     zk create $newNode
     zk delete $newNode -1 -async delete_async
@@ -558,7 +558,7 @@ test delete_async_normal {
 test delete_sync_version_wrong {
     try to delete a znode in sync mode with an incorrect version
 } -body {
-    set newNode [file join / deleteThis]
+    set newNode [file join $::params(zkTestRoot) deleteThis]
     zk create $newNode
     zk get $newNode -version dVersion
 
@@ -572,7 +572,7 @@ test delete_async_version_wrong {
     try to delete a znode in async mode with an incorrect version
 } -body {
 
-    set newNode [file join / deleteThis]
+    set newNode [file join $::params(zkTestRoot) deleteThis]
     zk create $newNode
     zk get $newNode -version dVersion
 
@@ -589,14 +589,14 @@ test delete_async_version_wrong {
 test delete_sync_madeup_znode {
     try to delete a znode in sync mode whose path does not exist
 } -body {
-    catch {zk delete /madeUp -1}
+    catch {zk delete [file join $::params(zkTestRoot) madeUp] -1}
     puts $::errorCode
 } -output ZNONODE -match regexp
 
 test delete_async_madeup_znode {
     try to delete a znode in async mode whose path does not exist
 } -body {
-    zk delete /madeUp -1 -async delete_async
+    zk delete [file join $::params(zkTestRoot) madeUp] -1 -async delete_async
 
     set asyncTimeout [after $::params(zkSyncTimeout) {set ::deleteAsync {status TIMEOUT}}]
     vwait ::deleteAsync

--- a/tests/api.test
+++ b/tests/api.test
@@ -8,6 +8,21 @@ proc create_async {cDict} {
     set ::createAsync $cDict
 }
 
+proc exists_async {eDict} {
+    set ::existsAsync $eDict
+}
+
+proc children_async {cDict} {
+    set ::childrenAsync $cDict
+}
+
+proc set_async {sDict} {
+    set ::setAsync $sDict
+}
+
+proc delete_async {dDict} {
+    set ::deleteAsync $dDict
+}
 
 #
 #
@@ -126,37 +141,166 @@ test create_numerous_sequential_nodes {
 #
 test exists_created_node_sync {
     create a node and check for its existence in sync mode
-}
+} -body {
+    set eNodePath [file join / createEphem]
+    zk create $eNodePath 
+
+    zk exists $eNodePath -version nodeVersion
+} -cleanup {
+    zk delete $eNodePath $nodeVersion
+} -result 1
 
 test exists_created_node_async {
     create a node and check for its existence in async mode
-}
+} -body {
+    set eNodePath [file join / createEphem]
+    zk create $eNodePath 
+
+    zk exists $eNodePath -async exists_async 
+    vwait ::existsAsync
+
+    return [dict get $::existsAsync status]
+} -cleanup {
+    zk delete $eNodePath [dict get $::existsAsync version]
+} -result ZOK
 
 test exists_deleted_node_sync {
+    check for the existence of a node that does not exist in sync mode
+} -body {
+    set eNodePath [file join / createEphem]
+    zk create $eNodePath 
+    zk delete $eNodePath -1
 
-}
+    # test several invocations of exists
+    set e1 [zk exists $eNodePath -version nodeVersion]
+    set e2 [zk exists $eNodePath -stat statArray]
+    set e3 [zk exists $eNodePath]
+
+    # if any of them return 1, this should fail
+    return [expr {$e1 || $e2 || $e3}]
+} -result 0
 
 test exists_deleted_node_async {
+    check for the existence of a node that does not exist in async mode
+} -body {
+    set eNodePath [file join / createEphem]
+    zk create $eNodePath 
+    zk delete $eNodePath -1
 
-}
+    zk exists $eNodePath -async exists_async 
+    vwait ::existsAsync
+
+    return [dict get $::existsAsync status]
+} -result ZNONODE
 
 #
 #
 # CHILDREN
 #
 #
+test children_sync_normal {
+    create several children in sync mode and test for their existence
+} -body {
+    set parentPath [file join / children]
+    zk create $parentPath
+
+    set children {0 1 2 3 4 5 6 7 8 9}
+    foreach child $children {
+	zk create [file join $parentPath $child]	
+    }
+
+    set zkChildren [lsort -integer [zk children $parentPath]]
+    return [expr {$children eq $zkChildren}]
+} -cleanup {
+    foreach child $children {
+	zk delete [file join $parentPath $child] -1
+    }
+} -result 1
+
+test children_async_normal {
+    create several children in async mode and test for their existence
+} -body {
+    set parentPath [file join / children]
+    zk create $parentPath
+
+    set children {0 1 2 3 4 5 6 7 8 9}
+    foreach child $children {
+	zk create [file join $parentPath $child]	
+    }
+
+    zk children $parentPath -async children_async
+    vwait ::childrenAsync
+} -cleanup {
+    foreach child $children {
+	zk delete [file join $parentPath $child] -1
+    }
+} -result 1
+
+test children_sync_no_children {
+    check for children in sync mode on a znode that has no children
+}
+
+test children_async_no_children {
+    check for children in async mode on a znode that has no children
+} 
 
 #
 #
 # SET
 #
 #
+test set_sync_normal {
+
+}
+
+test set_async_normal {
+
+}
+
+test set_sync_version_wrong {
+
+}
+
+test set_async_version_wrong {
+
+}
+
+test set_sync_madeup_znode {
+
+}
+
+test set_async_madeup_znode {
+
+}
 
 #
 #
 # DELETE
 #
 #
+test delete_sync_normal {
+
+}
+
+test delete_async_normal {
+
+}
+
+test delete_sync_version_wrong {
+
+}
+
+test delete_async_version_wrong {
+
+}
+
+test delete_sync_madeup_znode {
+
+}
+
+test delete_async_madeup_znode {
+
+}
 
 cleanupTests
 

--- a/tests/watches.test
+++ b/tests/watches.test
@@ -29,7 +29,7 @@ test get_watch_data_changed {
 
     zk get $newNodePath -watch watch_cb -version gVersion
     
-    after idle [list after 0 [list zk set $newNodePath newData $gVersion]]
+    zk set $newNodePath newData $gVersion
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
     after cancel $afterID
@@ -48,13 +48,13 @@ test get_watch_node_deleted {
 
     zk get $newNodePath -watch watch_cb -version gVersion
     
-    after idle [list after 0 [list zk delete $newNodePath $gVersion]]
+    zk delete $newNodePath $gVersion
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
     after cancel $afterID
 
     return [list [dict get $::watchData path] [dict get $::watchData type]]
-} -result {/testGetWatch deleted}
+} -result {/testGetWatch deleted} 
 
 test get_watch_not_fired_get_data {
     Ensure that a get watch does not fire when the data from the node is retrieved
@@ -64,8 +64,8 @@ test get_watch_not_fired_get_data {
     zk create $newNodePath -value $newNodeValue
 
     zk get $newNodePath -watch watch_cb -version gVersion
-    
-    after idle [list after 0 [list zk get $newNodePath]] 
+    zk get $newNodePath
+
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
     after cancel $afterID
@@ -82,6 +82,8 @@ test get_watch_not_fired_get_data {
 ##
 test children_watch_new_child {
     Ensure that a children watch is fired when a new child is created
+} -setup {
+    update
 } -body {
     set newNodeValue testingValueSync
     set newNodePath [file join / testChildWatch]
@@ -89,7 +91,8 @@ test children_watch_new_child {
     zk children $newNodePath -watch watch_cb
     
     set newChildPath [file join $newNodePath child0]
-    after idle [list after 0 [list zk create $newChildPath -value child]]
+    zk create $newChildPath -value child
+
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
     after cancel $afterID
@@ -111,7 +114,7 @@ test children_watch_child_deleted {
 
     zk children $newNodePath -watch watch_cb
     
-    after idle [list after 0 [list zk delete $newChildPath -1]]
+    zk delete $newChildPath -1
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
     after cancel $afterID
@@ -132,7 +135,7 @@ test children_watch_not_fired_get_data {
 
     zk children $newNodePath -watch watch_cb
     
-    after idle [list after 0 [list zk get $childNodePath -version gVersion]]
+    zk get $childNodePath -version gVersion
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
@@ -146,6 +149,8 @@ test children_watch_not_fired_get_data {
 
 test children_watch_not_fired_child_set_data {
     Ensure that a children watch is not fired when the data in a child is modified
+} -setup {
+    update
 } -body {
     set newNodePath [file join / testChildWatch]
     zk create $newNodePath -value childWatchTest
@@ -155,7 +160,7 @@ test children_watch_not_fired_child_set_data {
 
     zk children $newNodePath -watch watch_cb
     
-    after idle [list after 0 [list zk set $childNodePath newData -1]]
+    zk set $childNodePath newData -1
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
@@ -171,14 +176,16 @@ test children_watch_for_node_not_exists_then_created {
     Ensure that if a child watch is set on a node that does not exist and then
     that node is created that the watch does not fire when the node and a child
     are created
+} -setup {
+    update
 } -body {
     set newNodePath [file join / testChildNodeNotExists]
     zk children $newNodePath -watch watch_cb
 
     set newChildPath [file join $newNodePath newChild]
     
-    after idle [list after 0 [list zk create $newNodePath -value newData]]
-    after idle [list after 0 [list zk create $newChildPath -value newChild]]
+    zk create $newNodePath -value newData
+    zk create $newChildPath -value newChild
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
@@ -201,7 +208,7 @@ test exists_watch_create_node {
     set newNodePath [file join / testExistsWatch]
     zk exists $newNodePath -watch watch_cb
 
-    after idle [list after 0 [list zk create $newNodePath]]
+    zk create $newNodePath
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
@@ -220,7 +227,7 @@ test exists_watch_delete_node {
 
     zk exists $newNodePath -watch watch_cb
 
-    after idle [list after 0 [list zk delete $newNodePath -1]]
+    zk delete $newNodePath -1
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
@@ -237,7 +244,7 @@ test exists_watch_set_data {
     
     zk exists $newNodePath -watch watch_cb
 
-    after idle [list after 0 [list zk set $newNodePath newData -1]]
+    zk set $newNodePath newData -1
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
@@ -257,7 +264,7 @@ test exists_watch_not_fire_new_child {
     zk exists $newNodePath -watch watch_cb
 
     set newChildPath [file join $newNodePath child]
-    after idle [list after 0 [list zk create $newChildPath]] 
+    zk create $newChildPath
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData
@@ -271,13 +278,14 @@ test exists_watch_not_fire_new_child {
 
 test exists_watch_not_fire_get_data {
     Ensure that an exists watch does not fire when getting data from the node
+} -setup {
+    update
 } -body {
     set newNodePath [file join / testExistsWatch]
     zk create $newNodePath -value existsWatch
     
     zk exists $newNodePath -watch watch_cb
-
-    after idle [list after 0 [list zk get $newNodePath -version gVersion]] 
+    zk get $newNodePath -version gVersion
 
     set afterID [after 1500 {set ::watchData {path / type timeout}}]
     vwait ::watchData

--- a/tests/watches.test
+++ b/tests/watches.test
@@ -1,0 +1,269 @@
+##
+##
+## watches.test - Test watch callbacks for the following API
+##  commands:
+##  
+##  - GET
+##  - CHILDREN
+##  - EXISTS
+##
+##
+package require tcltest
+namespace import ::tcltest::*
+
+proc watch_cb {wDict} {
+    set ::watchData $wDict
+}
+
+##
+##
+## GET
+##
+##
+test get_watch_data_changed {
+    Ensure that a get watch fires when the data is changed
+} -body {
+    set newNodeValue testingValueSync
+    set newNodePath [file join / testGetWatch]
+    zk create $newNodePath -value $newNodeValue
+
+    zk get $newNodePath -watch watch_cb -version gVersion
+    
+    after idle [list after 0 [list zk set $newNodePath newData $gVersion]]
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newNodePath -1
+} -result {/testGetWatch changed}
+
+test get_watch_node_deleted {
+    Ensure that a get watch fires when the node is deleted
+} -body {
+    set newNodeValue testingValueSync
+    set newNodePath [file join / testGetWatch]
+    zk create $newNodePath -value $newNodeValue
+
+    zk get $newNodePath -watch watch_cb -version gVersion
+    
+    after idle [list after 0 [list zk delete $newNodePath $gVersion]]
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -result {/testGetWatch deleted}
+
+test get_watch_not_fired_get_data {
+    Ensure that a get watch does not fire when the data from the node is retrieved
+} -body {
+    set newNodeValue testingValueSync
+    set newNodePath [file join / testGetWatch]
+    zk create $newNodePath -value $newNodeValue
+
+    zk get $newNodePath -watch watch_cb -version gVersion
+    
+    after idle [list after 0 [list zk get $newNodePath]] 
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newNodePath $gVersion
+} -result {/ timeout}
+
+##
+##
+## CHILDREN
+##
+##
+test children_watch_new_child {
+    Ensure that a children watch is fired when a new child is created
+} -body {
+    set newNodeValue testingValueSync
+    set newNodePath [file join / testChildWatch]
+    zk create $newNodePath -value $newNodeValue
+    zk children $newNodePath -watch watch_cb
+    
+    set newChildPath [file join $newNodePath child0]
+    after idle [list after 0 [list zk create $newChildPath -value child]]
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newChildPath -1
+    zk delete $newNodePath -1
+} -result {/testChildWatch child}
+
+test children_watch_child_deleted {
+    Ensure that a children watch is fired when a child is deleted
+} -body {
+    set newNodePath [file join / testChildWatch]
+    zk create $newNodePath -value childTest
+
+    set newChildPath [file join $newNodePath child0]
+    zk create $newChildPath -value newChild
+
+    zk children $newNodePath -watch watch_cb
+    
+    after idle [list after 0 [list zk delete $newChildPath -1]]
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newNodePath -1
+} -result {/testChildWatch child}
+
+test children_watch_not_fired_get_data {
+    Ensure that a children watch is not fired when the data in a child is retrieved
+} -body {
+    set newNodePath [file join / testChildWatch]
+    zk create $newNodePath -value childWatchTest
+
+    set childNodePath [file join $newNodePath child]
+    zk create $childNodePath -value newChild
+
+    zk children $newNodePath -watch watch_cb
+    
+    after idle [list after 0 [list zk get $childNodePath -version gVersion]]
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $childNodePath $gVersion
+    zk delete $newNodePath -1
+} -result {/ timeout}
+
+test children_watch_not_fired_child_set_data {
+    Ensure that a children watch is not fired when the data in a child is modified
+} -body {
+    set newNodePath [file join / testChildWatch]
+    zk create $newNodePath -value childWatchTest
+
+    set childNodePath [file join $newNodePath child]
+    zk create $childNodePath -value newChild
+
+    zk children $newNodePath -watch watch_cb
+    
+    after idle [list after 0 [list zk set $childNodePath newData -1]]
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $childNodePath -1
+    zk delete $newNodePath -1
+} -result {/ timeout}
+
+##
+##
+## EXISTS
+##
+##
+test exists_watch_create_node {
+    Ensure that an exists watch fires when the node is created
+} -body {
+    set newNodePath [file join / testExistsWatch]
+    zk exists $newNodePath -watch watch_cb
+
+    after idle [list after 0 [list zk create $newNodePath]]
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newNodePath -1
+} -result {/testExistsWatch created}
+
+test exists_watch_delete_node {
+    Ensure that an exists watch fires when the node is deleted
+} -body {
+    set newNodePath [file join / testExistsWatch]
+    zk create $newNodePath -value existsWatch
+
+    zk exists $newNodePath -watch watch_cb
+
+    after idle [list after 0 [list zk delete $newNodePath -1]]
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -result {/testExistsWatch deleted}
+
+test exists_watch_set_data {
+    Ensure that an exists watch fires when setting data on the node
+} -body {
+    set newNodePath [file join / testExistsWatch]
+    zk create $newNodePath -value existsWatch
+    
+    zk exists $newNodePath -watch watch_cb
+
+    after idle [list after 0 [list zk set $newNodePath newData -1]]
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newNodePath -1
+} -result {/testExistsWatch changed}
+
+test exists_watch_not_fire_new_child {
+    Ensure an exists watch does not fire when a new child node is created
+} -body {
+    set newNodePath [file join / testExistsWatch]
+    zk create $newNodePath -value existsWatch
+    
+    zk exists $newNodePath -watch watch_cb
+
+    set newChildPath [file join $newNodePath child]
+    after idle [list after 0 [list zk create $newChildPath]] 
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newChildPath -1
+    zk delete $newNodePath -1
+} -result {/ timeout}
+
+test exists_watch_not_fire_get_data {
+    Ensure that an exists watch does not fire when getting data from the node
+} -body {
+    set newNodePath [file join / testExistsWatch]
+    zk create $newNodePath -value existsWatch
+    
+    zk exists $newNodePath -watch watch_cb
+
+    after idle [list after 0 [list zk get $newNodePath -version gVersion]] 
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newNodePath $gVersion
+} -result {/ timeout}
+
+
+# vim: set ts=8 sw=4 sts=4 noet :

--- a/tests/watches.test
+++ b/tests/watches.test
@@ -265,5 +265,6 @@ test exists_watch_not_fire_get_data {
     zk delete $newNodePath $gVersion
 } -result {/ timeout}
 
+cleanupTests
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/tests/watches.test
+++ b/tests/watches.test
@@ -24,7 +24,7 @@ test get_watch_data_changed {
     Ensure that a get watch fires when the data is changed
 } -body {
     set newNodeValue testingValueSync
-    set newNodePath [file join / testGetWatch]
+    set newNodePath [file join $::params(zkTestRoot) testGetWatch]
     zk create $newNodePath -value $newNodeValue
 
     zk get $newNodePath -watch watch_cb -version gVersion
@@ -34,16 +34,18 @@ test get_watch_data_changed {
     vwait ::watchData
     after cancel $afterID
 
-    return [list [dict get $::watchData path] [dict get $::watchData type]]
+    set pathEqual [expr {[dict get $::watchData path] eq $newNodePath}]
+    set typeEqual [expr {[dict get $::watchData type] eq "changed"}]
+    return [expr {$pathEqual && $typeEqual}]
 } -cleanup {
     zk delete $newNodePath -1
-} -result {/testGetWatch changed}
+} -result 1
 
 test get_watch_node_deleted {
     Ensure that a get watch fires when the node is deleted
 } -body {
     set newNodeValue testingValueSync
-    set newNodePath [file join / testGetWatch]
+    set newNodePath [file join $::params(zkTestRoot) testGetWatch]
     zk create $newNodePath -value $newNodeValue
 
     zk get $newNodePath -watch watch_cb -version gVersion
@@ -53,14 +55,16 @@ test get_watch_node_deleted {
     vwait ::watchData
     after cancel $afterID
 
-    return [list [dict get $::watchData path] [dict get $::watchData type]]
-} -result {/testGetWatch deleted} 
+    set pathEqual [expr {[dict get $::watchData path] eq $newNodePath}]
+    set typeEqual [expr {[dict get $::watchData type] eq "deleted"}]
+    return [expr {$pathEqual && $typeEqual}]
+} -result 1
 
 test get_watch_not_fired_get_data {
     Ensure that a get watch does not fire when the data from the node is retrieved
 } -body {
     set newNodeValue testingValueSync
-    set newNodePath [file join / testGetWatch]
+    set newNodePath [file join $::params(zkTestRoot) testGetWatch]
     zk create $newNodePath -value $newNodeValue
 
     zk get $newNodePath -watch watch_cb -version gVersion
@@ -86,7 +90,7 @@ test children_watch_new_child {
     update
 } -body {
     set newNodeValue testingValueSync
-    set newNodePath [file join / testChildWatch]
+    set newNodePath [file join $::params(zkTestRoot) testChildWatch]
     zk create $newNodePath -value $newNodeValue
     zk children $newNodePath -watch watch_cb
     
@@ -97,16 +101,18 @@ test children_watch_new_child {
     vwait ::watchData
     after cancel $afterID
 
-    return [list [dict get $::watchData path] [dict get $::watchData type]]
+    set pathEqual [expr {[dict get $::watchData path] eq $newNodePath}]
+    set typeEqual [expr {[dict get $::watchData type] eq "child"}]
+    return [expr {$pathEqual && $typeEqual}]
 } -cleanup {
     zk delete $newChildPath -1
     zk delete $newNodePath -1
-} -result {/testChildWatch child}
+} -result 1
 
 test children_watch_child_deleted {
     Ensure that a children watch is fired when a child is deleted
 } -body {
-    set newNodePath [file join / testChildWatch]
+    set newNodePath [file join $::params(zkTestRoot) testChildWatch]
     zk create $newNodePath -value childTest
 
     set newChildPath [file join $newNodePath child0]
@@ -119,15 +125,17 @@ test children_watch_child_deleted {
     vwait ::watchData
     after cancel $afterID
 
-    return [list [dict get $::watchData path] [dict get $::watchData type]]
+    set pathEqual [expr {[dict get $::watchData path] eq $newNodePath}]
+    set typeEqual [expr {[dict get $::watchData type] eq "child"}]
+    return [expr {$pathEqual && $typeEqual}]
 } -cleanup {
     zk delete $newNodePath -1
-} -result {/testChildWatch child}
+} -result 1
 
 test children_watch_not_fired_get_data {
     Ensure that a children watch is not fired when the data in a child is retrieved
 } -body {
-    set newNodePath [file join / testChildWatch]
+    set newNodePath [file join $::params(zkTestRoot) testChildWatch]
     zk create $newNodePath -value childWatchTest
 
     set childNodePath [file join $newNodePath child]
@@ -152,7 +160,7 @@ test children_watch_not_fired_child_set_data {
 } -setup {
     update
 } -body {
-    set newNodePath [file join / testChildWatch]
+    set newNodePath [file join $::params(zkTestRoot) testChildWatch]
     zk create $newNodePath -value childWatchTest
 
     set childNodePath [file join $newNodePath child]
@@ -179,7 +187,7 @@ test children_watch_for_node_not_exists_then_created {
 } -setup {
     update
 } -body {
-    set newNodePath [file join / testChildNodeNotExists]
+    set newNodePath [file join $::params(zkTestRoot) testChildNodeNotExists]
     zk children $newNodePath -watch watch_cb
 
     set newChildPath [file join $newNodePath newChild]
@@ -205,7 +213,7 @@ test children_watch_for_node_not_exists_then_created {
 test exists_watch_create_node {
     Ensure that an exists watch fires when the node is created
 } -body {
-    set newNodePath [file join / testExistsWatch]
+    set newNodePath [file join $::params(zkTestRoot) testExistsWatch]
     zk exists $newNodePath -watch watch_cb
 
     zk create $newNodePath
@@ -214,15 +222,17 @@ test exists_watch_create_node {
     vwait ::watchData
     after cancel $afterID
 
-    return [list [dict get $::watchData path] [dict get $::watchData type]]
+    set pathEqual [expr {[dict get $::watchData path] eq $newNodePath}]
+    set typeEqual [expr {[dict get $::watchData type] eq "created"}]
+    return [expr {$pathEqual && $typeEqual}]
 } -cleanup {
     zk delete $newNodePath -1
-} -result {/testExistsWatch created}
+} -result 1
 
 test exists_watch_delete_node {
     Ensure that an exists watch fires when the node is deleted
 } -body {
-    set newNodePath [file join / testExistsWatch]
+    set newNodePath [file join $::params(zkTestRoot) testExistsWatch]
     zk create $newNodePath -value existsWatch
 
     zk exists $newNodePath -watch watch_cb
@@ -233,8 +243,10 @@ test exists_watch_delete_node {
     vwait ::watchData
     after cancel $afterID
 
-    return [list [dict get $::watchData path] [dict get $::watchData type]]
-} -result {/testExistsWatch deleted}
+    set pathEqual [expr {[dict get $::watchData path] eq $newNodePath}]
+    set typeEqual [expr {[dict get $::watchData type] eq "deleted"}]
+    return [expr {$pathEqual && $typeEqual}]
+} -result 1
 
 test exists_watch_set_data {
     Ensure that an exists watch fires when setting data on the node
@@ -250,15 +262,17 @@ test exists_watch_set_data {
     vwait ::watchData
     after cancel $afterID
 
-    return [list [dict get $::watchData path] [dict get $::watchData type]]
+    set pathEqual [expr {[dict get $::watchData path] eq $newNodePath}]
+    set typeEqual [expr {[dict get $::watchData type] eq "changed"}]
+    return [expr {$pathEqual && $typeEqual}]
 } -cleanup {
     zk delete $newNodePath -1
-} -result {/testExistsWatch changed}
+} -result 1
 
 test exists_watch_not_fire_new_child {
     Ensure an exists watch does not fire when a new child node is created
 } -body {
-    set newNodePath [file join / testExistsWatch]
+    set newNodePath [file join $::params(zkTestRoot) testExistsWatch]
     zk create $newNodePath -value existsWatch
     
     zk exists $newNodePath -watch watch_cb
@@ -281,7 +295,7 @@ test exists_watch_not_fire_get_data {
 } -setup {
     update
 } -body {
-    set newNodePath [file join / testExistsWatch]
+    set newNodePath [file join $::params(zkTestRoot) testExistsWatch]
     zk create $newNodePath -value existsWatch
     
     zk exists $newNodePath -watch watch_cb

--- a/tests/watches.test
+++ b/tests/watches.test
@@ -167,6 +167,28 @@ test children_watch_not_fired_child_set_data {
     zk delete $newNodePath -1
 } -result {/ timeout}
 
+test children_watch_for_node_not_exists_then_created {
+    Ensure that if a child watch is set on a node that does not exist and then
+    that node is created that ...
+} -body {
+    set newNodePath [file join / testChildNodeNotExists]
+    zk children $newNodePath -watch watch_cb
+
+    set newChildPath [file join $newNodePath newChild]
+    
+    after idle [list after 0 [list zk create $newNodePath -value newData]]
+    after idle [list after 0 [list zk create $newChildPath -value newChild]]
+
+    set afterID [after 1500 {set ::watchData {path / type timeout}}]
+    vwait ::watchData
+    after cancel $afterID
+
+    return [list [dict get $::watchData path] [dict get $::watchData type]]
+} -cleanup {
+    zk delete $newChildPath -1
+    zk delete $newNodePath -1
+} -result {/ timeout}
+
 ##
 ##
 ## EXISTS

--- a/tests/watches.test
+++ b/tests/watches.test
@@ -169,7 +169,8 @@ test children_watch_not_fired_child_set_data {
 
 test children_watch_for_node_not_exists_then_created {
     Ensure that if a child watch is set on a node that does not exist and then
-    that node is created that ...
+    that node is created that the watch does not fire when the node and a child
+    are created
 } -body {
     set newNodePath [file join / testChildNodeNotExists]
     zk children $newNodePath -watch watch_cb

--- a/tests/zookeepertcl.test
+++ b/tests/zookeepertcl.test
@@ -50,4 +50,6 @@ test copy_data_node_exists_null_data {
     zk delete $zpath -1
 } -result newData
 
+cleanupTests
+
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/tests/zookeepertcl.test
+++ b/tests/zookeepertcl.test
@@ -13,13 +13,13 @@ test rmrf {
     zk create $rootPath -value root
 
     for {set i 0} {$i < 10} {incr i} {
-	set childLevel1 [file join $rootPath $i]
-	zk create $childLevel1
+        set childLevel1 [file join $rootPath $i]
+        zk create $childLevel1
 
-	for {set j 0} {$j < 10} {incr j} {
-	    set childLevel2 [file join $childLevel1 $j]
-	    zk create $childLevel2 
-	}
+        for {set j 0} {$j < 10} {incr j} {
+            set childLevel2 [file join $childLevel1 $j]
+            zk create $childLevel2 
+        }
     }
 
     zookeeper::rmrf zk $rootPath

--- a/tests/zookeepertcl.test
+++ b/tests/zookeepertcl.test
@@ -1,0 +1,53 @@
+##
+##
+## zookeepertcl.test - Test the Tcl helpers procs defined in the
+##  zookeepertcl package 
+##
+package require tcltest
+namespace import ::tcltest::*
+
+test rmrf {
+    Make sure all child paths are deleted recursively
+} -body {
+    set rootPath [file join / rmrfRoot]
+    zk create $rootPath -value root
+
+    for {set i 0} {$i < 10} {incr i} {
+	set childLevel1 [file join $rootPath $i]
+	zk create $childLevel1
+
+	for {set j 0} {$j < 10} {incr j} {
+	    set childLevel2 [file join $childLevel1 $j]
+	    zk create $childLevel2 
+	}
+    }
+
+    zookeeper::rmrf zk $rootPath
+    return [zk exists $rootPath]
+} -result 0
+
+test mkpath {
+    Make sure all paths get created
+} -body {
+    set paths [file join / root child0 child1 child2 child3 child4]
+    zookeeper::mkpath zk $paths
+    return [zk exists $paths] 
+} -cleanup {
+    zookeeper::rmrf zk /root
+} -result 1
+
+test copy_data_node_exists_null_data {
+    Test that the copy_data proc works when the node has no data
+} -body {
+    set zpath [file join / zpath]
+    zk create $zpath
+
+    zookeeper::copy_data zk newData $zpath
+
+    zk get $zpath -data gData -version gVersion
+    return $gData
+} -cleanup {
+    zk delete $zpath -1
+} -result newData
+
+# vim: set ts=8 sw=4 sts=4 noet :

--- a/zookeeper.tcl
+++ b/zookeeper.tcl
@@ -191,24 +191,14 @@ namespace eval ::zookeeper  {
 		return
 	}
 
-
 	#
-	# zdigest - given a username and a password for use with the digest
-	#  ACL scheme, return the base-64 encoded SHA1 hex string of 
-	#  the password
-	#
-	proc zdigest {username password} {
-		return [base64::encode [sha1::sha1 "${username}:${password}"]]
-	}
-
-	
-	#
-	# zdigestID - given a username and password for use with the digest
+	# zdigest_id - given a username and password for use with the digest
 	#  ACL scheme, return the id portion of the ACL, which is
 	#  username:[zdigest password]
 	#
-	proc zdigestID {username password} {
-		return [format {%s:%s} $username [zdigest $username $password]]
+	proc zdigest_id {un pw} {
+		set digest [base64::encode [sha1::sha1 -bin "${un}:${pw}"]]
+		return [format {%s:%s} $un $digest]
 	}
 
 } ;# namespace ::zookeeper

--- a/zookeeper.tcl
+++ b/zookeeper.tcl
@@ -67,7 +67,7 @@ namespace eval ::zookeeper  {
 
 		if {[$zk get $zpath -data zdata -version zversion]} {
 			# if it matches the file, leave it alone
-			if {$data == $zdata} {
+			if {[info exists zdata] && $data == $zdata} {
 				return
 			}
 		} else {
@@ -113,7 +113,7 @@ namespace eval ::zookeeper  {
 			set exists 0
 		}
 
-		if {![$zk get $zpath -data zdata -version zversion]} {
+		if {![$zk get $zpath -data zdata -version zversion] || ![info exists zdata]} {
 			# there is no data at the znode.  if there is a file,
 			# delete it.
 			if {$exists} {
@@ -161,10 +161,6 @@ namespace eval ::zookeeper  {
 		foreach znode $children {
 			sync_ztree_to_directory $zk [file join $zpath $znode] $path
 		}
-	}
-
-	proc flatten_path {zpath} {
-		# take out .. and whatever preceded it and anchor to /
 	}
 
 	proc zls {{where ""}} {

--- a/zookeeper.tcl
+++ b/zookeeper.tcl
@@ -3,6 +3,9 @@
 #
 #
 
+package require base64
+package require sha1
+
 namespace eval ::zookeeper  {
 	variable zkwd "/"
 
@@ -188,9 +191,26 @@ namespace eval ::zookeeper  {
 		return
 	}
 
-	proc zcat {{what ""}} {
-		variable zkwd
+
+	#
+	# zdigest - given a username and a password for use with the digest
+	#  ACL scheme, return the base-64 encoded SHA1 hex string of 
+	#  the password
+	#
+	proc zdigest {username password} {
+		return [base64::encode [sha1::sha1 "${username}:${password}"]]
 	}
+
+	
+	#
+	# zdigestID - given a username and password for use with the digest
+	#  ACL scheme, return the id portion of the ACL, which is
+	#  username:[zdigest password]
+	#
+	proc zdigestID {username password} {
+		return [format {%s:%s} $username [zdigest $username $password]]
+	}
+
 } ;# namespace ::zookeeper
 
 # vim: set ts=4 sw=4 sts=4 noet :


### PR DESCRIPTION
This PR makes several major changes to `zookeepertcl`:

## Sync API

Currently, all sync API calls in `zookeepertcl` actually use the async functions in the Zookeeper  C client.  To make these sync API calls appear to block to the Tcl caller, `zookeepertcl` uses the function `zootcl_wait`, which has the unfortunate side effect of manually calling `Tcl_DoOneEvent(TCL_ALL_EVENTS)`, i.e., it enters the event loop.  However, if the Tcl client code is already in the event loop, this could cause hard-to-track-down bugs because it requires that the client code is re-entrant.  Moreover, having a sync API that is actually async violates expectations; if a client wants a sync-like API that actually uses async calls, this can be implemented on top of the async API.  In order to avoid using `zootcl_wait`, then, this PR uses the actual sync calls in the Zookeeper C client.

## New Subcommands

A few new subcommands have been added to Zookeeper objects:

- `destroy` and `close`: these are synonyms and end up closing the connection to Zookeeper and deleting the `zookeepertcl` handle
- `server`: this returns the hostname or IP of the Zookeeper server currently connected to.  In a clustered environment, this allows for the client to figure out which node in the cluster is being used

## API Changes

For the `get` subcommand, this PR makes the following modification:

- When the `-data` option is provided for an extant znode but the data is `NULL`, `get` returns `1` and unsets the variable specified by `-data`

In the current code, this scenario would return `0`, although the README states 

> If -data is specified, dataVar is the name of an array that the data is stored into, and get returns 1 if the znode exists and 0 if it doesn't.

## Unit Tests

This PR also adds a number of unit tests in the `tests/` directory.  These tests require a functioning Zookeeper server / cluster and test the Zookeeper object subcommands, watch callbacks and some of the Tcl procs in the `zookeeper` namespace. 