### PR TITLE
Only delete events where the event's zo element matches the clientData passed to Tcl_DeleteEvents.

### DIFF
--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1100,8 +1100,9 @@ zootcl_EventProc (Tcl_Event *tevPtr, int flags) {
  *--------------------------------------------------------------
  */
 int zootcl_DeleteEventsForDeletedObject (Tcl_Event *tevPtr, ClientData clientData) {
+	zootcl_callbackEvent *zevPtr = (zootcl_callbackEvent *)tevPtr;
 	zootcl_objectClientData *zo = (zootcl_objectClientData *)clientData;    
-	return zo && zo->zookeeper_object_magic != ZOOKEEPER_OBJECT_MAGIC;
+	return zo && zevPtr->zo == zo;
 }
 
 /*


### PR DESCRIPTION
The existing code doesn't look at the event at all, which means (I think) that it will clean up the whole pending event queue. This is not the desired outcome.