### PR TITLE
Clean up some bugs in the callback handling

### DIFF
--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -1133,12 +1133,15 @@ zootcl_zookeeperObjectDelete (ClientData clientData)
 	}
 	Tcl_DeleteEventSource (zootcl_EventSetupProc, zootcl_EventCheckProc, (ClientData) zo);
 
+	// In some rare cases the init callback for zo may be hanging here
+	// so call zookeeper_close before invalidating the object.
+	zookeeper_close (zo->zh);
+
 	// we are freeing memory in a sec, clear the magic number
 	// so attempt to reuse a freed object will be an assertion
 	// failure
     	zo->zookeeper_object_magic = -1;
 
-	zookeeper_close (zo->zh);
 	Tcl_DeleteEvents (zootcl_DeleteEventsForDeletedObject, clientData);
 
     	ckfree((char *)clientData);

--- a/generic/zookeepertcl.c
+++ b/generic/zookeepertcl.c
@@ -2180,7 +2180,7 @@ zootcl_init_subcommand(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 	zo->currentFD = -1;
 	zo->initCallbackObj = callbackObj;
 
-	zhandle_t *zh = zookeeper_init (hosts, zootcl_init_callback, timeout, NULL, zo, 0);
+	zhandle_t *zh = zookeeper_init (hosts, callbackObj?zootcl_init_callback:NULL, timeout, NULL, zo, 0);
 
 	if (zh == NULL) {
 		Tcl_SetObjResult (interp, Tcl_NewStringObj (Tcl_PosixError (interp), -1));


### PR DESCRIPTION
In some rare cases if you open and close a connection fast enough, synchronously, the close can happen before the callback gets through the zookeeper event queue and the Tcl event queue. This fix handles both ends of the problem:

1. Don't set up the callback if you're performing the init synchronously. The previous code put an event on the queue and exited the event handler early if there was no callback routine. This passes null as the event handler for zookeeper_init if there's no callback.

2. Don't zap the magic number in the zookeeper object until after calling zookeeper_close, because its cleanup may fire any pending handlers.